### PR TITLE
do not fetch from dead Plasma Manager

### DIFF
--- a/src/common/state/db_client_table.cc
+++ b/src/common/state/db_client_table.cc
@@ -45,7 +45,9 @@ const std::vector<std::string> db_client_table_get_ip_addresses(
   for (auto const &manager_id : manager_ids) {
     DBClient client = redis_cache_get_db_client(db_handle, manager_id);
     RAY_CHECK(!client.manager_address.empty());
-    manager_vector.push_back(client.manager_address);
+    if (client.is_alive) {
+      manager_vector.push_back(client.manager_address);
+    }
   }
 
   int64_t end_time = current_time_ms();


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

- Problem
    During the execution of `cleanup_object_table()` in monitor.py, objects in the dead Plasma manager may be fetched by others. This manager has been marked as "deleted" but the object location tables may have not been cleaned up yet.
    This logic would cause: 1) unnecessary fetching attempts; 2) occasionally, if the recovered Plasma manager is in the same machine and takes the same listening port as the dead one, it may connect to itself during fetching and causes unpredictable results.
- Solution
    After looking up DB client table, filter the result to drop dead Plasma managers.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
