### PR TITLE
Improve connection_pool perf using unordered_set instead of vector

### DIFF
--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -91,10 +91,11 @@ class ConnectionPool {
  private:
   /// A container type that maps ClientID to a connection type.
   using SenderMapType =
-      std::unordered_map<ray::ClientID, std::vector<std::shared_ptr<SenderConnection>>>;
+      std::unordered_map<ray::ClientID,
+                         std::unordered_set<std::shared_ptr<SenderConnection>>>;
   using ReceiverMapType =
       std::unordered_map<ray::ClientID,
-                         std::vector<std::shared_ptr<TcpClientConnection>>>;
+                         std::unordered_set<std::shared_ptr<TcpClientConnection>>>;
 
   /// Adds a receiver for ClientID to the given map.
   void Add(ReceiverMapType &conn_map, const ClientID &client_id,

--- a/src/ray/object_manager/object_directory.cc
+++ b/src/ray/object_manager/object_directory.cc
@@ -17,7 +17,7 @@ void ObjectDirectory::RegisterBackend() {
       return;
     }
     // Update entries for this object.
-    auto client_id_set = entry->second.client_ids;
+    auto &client_id_set = entry->second.client_ids;
     for (auto &object_table_data : data) {
       ClientID client_id = ClientID::from_binary(object_table_data.manager);
       if (!object_table_data.is_eviction) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Improve connection_pool perf using unordered_set instead of vector
There are many operations like remove & find in the vector, which is slow in vector(O(n)). I change to unordered_set which has O(1) time complexcity. 
## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A