### PR TITLE
Build arrow for Python and Java simultaneously

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -61,11 +61,6 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
     fi
     cd build
 
-    BUILD_ARROW_PLASMA_JAVA_CLIENT=off
-    if [[ "$LANGUAGE" == "java" ]]; then
-      BUILD_ARROW_PLASMA_JAVA_CLIENT=on
-    fi
-
     ARROW_HOME=$TP_DIR/pkg/arrow/cpp/build/cpp-install
     BOOST_ROOT=$TP_DIR/pkg/boost \
     FLATBUFFERS_HOME=$FLATBUFFERS_HOME \
@@ -85,7 +80,7 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
         -DARROW_WITH_LZ4=off \
         -DARROW_WITH_ZLIB=off \
         -DARROW_WITH_ZSTD=off \
-        -DARROW_PLASMA_JAVA_CLIENT=$BUILD_ARROW_PLASMA_JAVA_CLIENT \
+        -DARROW_PLASMA_JAVA_CLIENT=on \
         ..
     make VERBOSE=1 -j$PARALLEL
     make install


### PR DESCRIPTION
## What do these changes do?

Now, Ray's build dir has been unified for Python and Java to `ray/build`, see [https://github.com/ray-project/ray/pull/2171](url). We can execute command `make` in the same dir to build Ray.

However, Ray's build depends on the third party lib: Arrow, and now when we build Ray for Python, we can only generate Python client, then if we want to build Ray for Java, Arrow will not be built again and Ray's build will fail. (BTW, if we build Ray for Java first, we will also generate arrow's Python client)

So, to solve the problem, we can generate both Python and Java client simultaneously when building Arrow. I know If user only wants Python client and we generate Java client simultaneously, that's useless, but Arrow as a third party lib, it only need to be built once. So generating Arrow's Python and Java client simultaneously is a good idea.