### PR TITLE
fix build error when building ray for python and java serially

### DIFF
--- a/python/ray/autoscaler/aws/node_provider.py
+++ b/python/ray/autoscaler/aws/node_provider.py
@@ -6,8 +6,26 @@ import boto3
 from botocore.config import Config
 
 from ray.autoscaler.node_provider import NodeProvider
-from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME
+from ray.autoscaler.tags import TAG_RAY_CLUSTER_NAME, TAG_RAY_NODE_NAME
 from ray.ray_constants import BOTO_MAX_RETRIES
+
+
+def to_aws_format(tags):
+    """Convert the Ray node name tag to the AWS-specific 'Name' tag."""
+
+    if TAG_RAY_NODE_NAME in tags:
+        tags["Name"] = tags[TAG_RAY_NODE_NAME]
+        del tags[TAG_RAY_NODE_NAME]
+    return tags
+
+
+def from_aws_format(tags):
+    """Convert the AWS-specific 'Name' tag to the Ray node name tag."""
+
+    if "Name" in tags:
+        tags[TAG_RAY_NODE_NAME] = tags["Name"]
+        del tags["Name"]
+    return tags
 
 
 class AWSNodeProvider(NodeProvider):
@@ -26,6 +44,7 @@ class AWSNodeProvider(NodeProvider):
         self.external_ip_cache = {}
 
     def nodes(self, tag_filters):
+        tag_filters = to_aws_format(tag_filters)
         filters = [
             {
                 "Name": "instance-state-name",
@@ -59,7 +78,7 @@ class AWSNodeProvider(NodeProvider):
         tags = {}
         for tag in node.tags:
             tags[tag["Key"]] = tag["Value"]
-        return tags
+        return from_aws_format(tags)
 
     def external_ip(self, node_id):
         if node_id in self.external_ip_cache:
@@ -80,6 +99,7 @@ class AWSNodeProvider(NodeProvider):
         return ip
 
     def set_node_tags(self, node_id, tags):
+        tags = to_aws_format(tags)
         node = self._node(node_id)
         tag_pairs = []
         for k, v in tags.items():
@@ -90,6 +110,7 @@ class AWSNodeProvider(NodeProvider):
         node.create_tags(Tags=tag_pairs)
 
     def create_node(self, node_config, tags, count):
+        tags = to_aws_format(tags)
         conf = node_config.copy()
         tag_pairs = [{
             "Key": TAG_RAY_CLUSTER_NAME,

--- a/python/ray/dataframe/dataframe.py
+++ b/python/ray/dataframe/dataframe.py
@@ -4926,9 +4926,8 @@ class DataFrame(object):
         return to_pandas(self).__array__(dtype=dtype)
 
     def __array_wrap__(self, result, context=None):
-        raise NotImplementedError(
-            "To contribute to Pandas on Ray, please visit "
-            "github.com/ray-project/ray.")
+        # TODO: This is very inefficient, see also __array__ and as_matrix
+        return to_pandas(self).__array_wrap__(result, context=context)
 
     def __getstate__(self):
         raise NotImplementedError(

--- a/python/ray/dataframe/test/test_dataframe.py
+++ b/python/ray/dataframe/test/test_dataframe.py
@@ -3191,13 +3191,6 @@ def test___array__(ray_df, pandas_df):
     assert np.array_equal(ray_df.__array__(), pandas_df.__array__())
 
 
-def test___array_wrap__():
-    ray_df = create_test_dataframe()
-
-    with pytest.raises(NotImplementedError):
-        ray_df.__array_wrap__(None)
-
-
 def test___getstate__():
     ray_df = create_test_dataframe()
 

--- a/python/ray/rllib/utils/tf_policy_graph.py
+++ b/python/ray/rllib/utils/tf_policy_graph.py
@@ -105,7 +105,7 @@ class TFPolicyGraph(PolicyGraph):
         feed_dict[self._is_training] = True
         for ph, value in zip(self._grads, gradients):
             feed_dict[ph] = value
-        fetches = self.sess.run(
+        fetches = self._sess.run(
             [self._apply_op, self.extra_apply_grad_fetches()],
             feed_dict=feed_dict)
         return fetches[1]

--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -41,8 +41,15 @@ else
 fi
 
 # Download and compile arrow if it isn't already present.
-if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
+if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow || \
+  "$LANGUAGE" == "java" && ! -f $TP_DIR/../build/src/plasma/libplasma_java.dylib ]]; then
     echo "building arrow"
+
+    if [[ "$LANGUAGE" == "java" && ! -f $TP_DIR/../build/src/plasma/libplasma_java.dylib ]]; then
+      rm -rf $TP_DIR/build/arrow
+      rm -rf $TP_DIR/build/parquet-cpp
+      rm -rf $TP_DIR/pkg/arrow
+    fi
 
     if [[ ! -d $TP_DIR/build/arrow ]]; then
       git clone https://github.com/apache/arrow.git "$TP_DIR/build/arrow"
@@ -53,7 +60,7 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
     # The PR for this commit is https://github.com/apache/arrow/pull/2065. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout ce23c06469de9cf0c3e38e35cdb8d135f341b964
+    git checkout 34890cc133d6761bdedc53e0b88374ccd7641c55
 
     cd cpp
     if [ ! -d "build" ]; then


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?

<!-- Please give a short brief about these changes. -->
Now, Ray supports both Python and Java client, we can build Ray for both. However, if we build ray for Python first and then build ray for Java, we'll fail. That's because Ray's build depends on Arrow which only be built once. Arrow will not generate libs for Java when building Ray for Python (BTW, if we build Ray for Java first, we will also generate arrow's Python client).

So, to solve the problem, we should make sure Arrow will be built again when building Ray for Java later.
