### PR TITLE
Allow Ray API to be used from multiple threads

### DIFF
--- a/python/ray/actor.py
+++ b/python/ray/actor.py
@@ -581,7 +581,6 @@ class ActorClass(object):
             A handle to the newly created actor.
         """
         worker = ray.worker.get_global_worker()
-        ray.worker.check_main_thread()
         if worker.mode is None:
             raise Exception("Actors cannot be created before ray.init() "
                             "has been called.")
@@ -760,7 +759,6 @@ class ActorHandle(object):
         worker = ray.worker.get_global_worker()
 
         worker.check_connected()
-        ray.worker.check_main_thread()
 
         function_signature = self._ray_method_signatures[method_name]
         if args is None:
@@ -913,7 +911,6 @@ class ActorHandle(object):
         """
         worker = ray.worker.get_global_worker()
         worker.check_connected()
-        ray.worker.check_main_thread()
 
         if state["ray_forking"]:
             actor_handle_id = compute_actor_handle_id(

--- a/python/ray/remote_function.py
+++ b/python/ray/remote_function.py
@@ -114,7 +114,6 @@ class RemoteFunction(object):
         """An experimental alternate way to submit remote functions."""
         worker = ray.worker.get_global_worker()
         worker.check_connected()
-        ray.worker.check_main_thread()
         kwargs = {} if kwargs is None else kwargs
         args = ray.signature.extend_args(self._function_signature, args,
                                          kwargs)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -219,7 +219,16 @@ def merge_dicts(d1, d2):
     return d
 
 
-class ThreadSafeProxy(object):
+class _ThreadSafeProxy(object):
+    """This class is used to create a thread-safe proxy for a given object.
+        Every method call will be guarded with a lock.
+
+    Attributes:
+        orig_obj (object): the original object.
+        lock (threading.Lock): the lock object.
+        _wrapper_cache (dict): a cache from original object's methods to the proxy methods.
+    """
+
 
     def __init__(self, orig_obj, lock):
         self.orig_obj = orig_obj
@@ -228,7 +237,12 @@ class ThreadSafeProxy(object):
 
     def __getattr__(self, attr):
         orig_attr = getattr(self.orig_obj, attr)
-        if callable(orig_attr):
+        if not callable(orig_attr):
+            # If the original attr is a field, just return it.
+            return orig_attr
+        else:
+            # If the orginal attr is a method,
+            # return a wrapper that guards the original method with a lock.
             wrapper = self._wrapper_cache.get(attr)
             if wrapper is None:
                 @functools.wraps(orig_attr)
@@ -237,12 +251,19 @@ class ThreadSafeProxy(object):
                         return orig_attr(*args, **kwargs)
                 self._wrapper_cache[attr] = wrapper = _wrapper
             return wrapper
-        else:
-            return orig_attr
 
 
 def thread_safe_client(client, lock=None):
-    """Create a thread safe proxy which guards every method call with a lock, for the given client."""
+    """Create a thread-safe proxy which locks every method call for the given client.
+
+    Args:
+        client: the client object to be guarded.
+        lock: the lock object that will be used to lock client's methods.
+            If None, a new lock will be used.
+
+    Returns:
+        A thread-safe proxy for the given client.
+    """
     if lock is None:
         lock = threading.Lock()
-    return ThreadSafeProxy(client, lock)
+    return _ThreadSafeProxy(client, lock)

--- a/python/ray/utils.py
+++ b/python/ray/utils.py
@@ -3,10 +3,12 @@ from __future__ import division
 from __future__ import print_function
 
 import binascii
+import functools
 import hashlib
 import numpy as np
 import os
 import sys
+import threading
 import uuid
 
 import ray.local_scheduler
@@ -215,3 +217,32 @@ def merge_dicts(d1, d2):
     d = d1.copy()
     d.update(d2)
     return d
+
+
+class ThreadSafeProxy(object):
+
+    def __init__(self, orig_obj, lock):
+        self.orig_obj = orig_obj
+        self.lock = lock
+        self._wrapper_cache = {}
+
+    def __getattr__(self, attr):
+        orig_attr = getattr(self.orig_obj, attr)
+        if callable(orig_attr):
+            wrapper = self._wrapper_cache.get(attr)
+            if wrapper is None:
+                @functools.wraps(orig_attr)
+                def _wrapper(*args, **kwargs):
+                    with self.lock:
+                        return orig_attr(*args, **kwargs)
+                self._wrapper_cache[attr] = wrapper = _wrapper
+            return wrapper
+        else:
+            return orig_attr
+
+
+def thread_safe_client(client, lock=None):
+    """Create a thread safe proxy which guards every method call with a lock, for the given client."""
+    if lock is None:
+        lock = threading.Lock()
+    return ThreadSafeProxy(client, lock)

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -203,6 +203,7 @@ class Worker(object):
             that connect has been called already.
         cached_functions_to_run (List): A list of functions to run on all of
             the workers that should be exported as soon as connect is called.
+        reconstruction_lock (Lock): A lock object used to guard object reconstruction.
     """
 
     def __init__(self):
@@ -238,6 +239,7 @@ class Worker(object):
         # When the worker is constructed. Record the original value of the
         # CUDA_VISIBLE_DEVICES environment variable.
         self.original_gpu_ids = ray.utils.get_cuda_visible_devices()
+        self.reconstruction_lock = threading.Lock()
 
     def check_connected(self):
         """Check if the worker is connected.
@@ -467,51 +469,52 @@ class Worker(object):
             for (i, val) in enumerate(final_results)
             if val is plasma.ObjectNotAvailable
         }
-        was_blocked = (len(unready_ids) > 0)
-        # Try reconstructing any objects we haven't gotten yet. Try to get them
-        # until at least get_timeout_milliseconds milliseconds passes, then
-        # repeat.
-        while len(unready_ids) > 0:
-            for unready_id in unready_ids:
-                self.local_scheduler_client.reconstruct_objects(
-                    [ray.ObjectID(unready_id)], False)
-            # Do another fetch for objects that aren't available locally yet,
-            # in case they were evicted since the last fetch. We divide the
-            # fetch into smaller fetches so as to not block the manager for a
-            # prolonged period of time in a single call.
-            object_ids_to_fetch = list(
-                map(plasma.ObjectID, unready_ids.keys()))
-            ray_object_ids_to_fetch = list(
-                map(ray.ObjectID, unready_ids.keys()))
-            for i in range(0, len(object_ids_to_fetch),
-                           ray._config.worker_fetch_request_size()):
-                if not self.use_raylet:
-                    self.plasma_client.fetch(object_ids_to_fetch[i:(
-                        i + ray._config.worker_fetch_request_size())])
-                else:
-                    self.local_scheduler_client.reconstruct_objects(
-                        ray_object_ids_to_fetch[i:(
-                            i + ray._config.worker_fetch_request_size())],
-                        True)
-            results = self.retrieve_and_deserialize(
-                object_ids_to_fetch,
-                max([
-                    ray._config.get_timeout_milliseconds(),
-                    int(0.01 * len(unready_ids))
-                ]))
-            # Remove any entries for objects we received during this iteration
-            # so we don't retrieve the same object twice.
-            for i, val in enumerate(results):
-                if val is not plasma.ObjectNotAvailable:
-                    object_id = object_ids_to_fetch[i].binary()
-                    index = unready_ids[object_id]
-                    final_results[index] = val
-                    unready_ids.pop(object_id)
 
-        # If there were objects that we weren't able to get locally, let the
-        # local scheduler know that we're now unblocked.
-        if was_blocked:
-            self.local_scheduler_client.notify_unblocked()
+        if len(unready_ids) > 0:
+            with self.reconstruction_lock:
+                # Try reconstructing any objects we haven't gotten yet. Try to get them
+                # until at least get_timeout_milliseconds milliseconds passes, then
+                # repeat.
+                while len(unready_ids) > 0:
+                    for unready_id in unready_ids:
+                        self.local_scheduler_client.reconstruct_objects(
+                            [ray.ObjectID(unready_id)], False)
+                    # Do another fetch for objects that aren't available locally yet,
+                    # in case they were evicted since the last fetch. We divide the
+                    # fetch into smaller fetches so as to not block the manager for a
+                    # prolonged period of time in a single call.
+                    object_ids_to_fetch = list(
+                        map(plasma.ObjectID, unready_ids.keys()))
+                    ray_object_ids_to_fetch = list(
+                        map(ray.ObjectID, unready_ids.keys()))
+                    for i in range(0, len(object_ids_to_fetch),
+                                   ray._config.worker_fetch_request_size()):
+                        if not self.use_raylet:
+                            self.plasma_client.fetch(object_ids_to_fetch[i:(
+                                i + ray._config.worker_fetch_request_size())])
+                        else:
+                            self.local_scheduler_client.reconstruct_objects(
+                                ray_object_ids_to_fetch[i:(
+                                    i + ray._config.worker_fetch_request_size())],
+                                True)
+                    results = self.retrieve_and_deserialize(
+                        object_ids_to_fetch,
+                        max([
+                            ray._config.get_timeout_milliseconds(),
+                            int(0.01 * len(unready_ids))
+                        ]))
+                    # Remove any entries for objects we received during this iteration
+                    # so we don't retrieve the same object twice.
+                    for i, val in enumerate(results):
+                        if val is not plasma.ObjectNotAvailable:
+                            object_id = object_ids_to_fetch[i].binary()
+                            index = unready_ids[object_id]
+                            final_results[index] = val
+                            unready_ids.pop(object_id)
+
+                # If there were objects that we weren't able to get locally, let the
+                # local scheduler know that we're now unblocked.
+                self.local_scheduler_client.notify_unblocked()
 
         assert len(final_results) == len(object_ids)
         return final_results

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -29,7 +29,12 @@ import ray.signature
 import ray.local_scheduler
 import ray.plasma
 import ray.ray_constants as ray_constants
-from ray.utils import random_string, binary_to_hex, is_cython
+from ray.utils import (
+    binary_to_hex,
+    is_cython,
+    random_string,
+    thread_safe_client,
+)
 
 # Import flatbuffer bindings.
 from ray.core.generated.ClientTableData import ClientTableData
@@ -558,7 +563,6 @@ class Worker(object):
             The return object IDs for this task.
         """
         with log_span("ray:submit_task", worker=self):
-            check_main_thread()
             if actor_id is None:
                 assert actor_handle_id is None
                 actor_id = ray.ObjectID(NIL_ACTOR_ID)
@@ -630,7 +634,6 @@ class Worker(object):
             decorated_function: The decorated function (this is used to enable
                 the remote function to recursively call itself).
         """
-        check_main_thread()
         if self.mode not in [SCRIPT_MODE, SILENT_MODE]:
             raise Exception("export_remote_function can only be called on a "
                             "driver.")
@@ -692,7 +695,6 @@ class Worker(object):
                 should not take any arguments. If it returns anything, its
                 return values will not be used.
         """
-        check_main_thread()
         # If ray.init has not been called yet, then cache the function and
         # export it when connect is called. Otherwise, run the function on all
         # workers.
@@ -1051,7 +1053,6 @@ class Worker(object):
 
         signal.signal(signal.SIGTERM, exit)
 
-        check_main_thread()
         while True:
             task = self._get_next_task_from_local_scheduler()
             self._wait_for_and_process_task(task)
@@ -1151,20 +1152,6 @@ class RayConnectionError(Exception):
     pass
 
 
-def check_main_thread():
-    """Check that we are currently on the main thread.
-
-    Raises:
-        Exception: An exception is raised if this is called on a thread other
-            than the main thread.
-    """
-    if threading.current_thread().getName() != "MainThread":
-        raise Exception("The Ray methods are not thread safe and must be "
-                        "called from the main thread. This method was called "
-                        "from thread {}."
-                        .format(threading.current_thread().getName()))
-
-
 def print_failed_task(task_status):
     """Print information about failed tasks.
 
@@ -1199,7 +1186,6 @@ def error_applies_to_driver(error_key, worker=global_worker):
 def error_info(worker=global_worker):
     """Return information about failed tasks."""
     worker.check_connected()
-    check_main_thread()
     error_keys = worker.redis_client.lrange("ErrorKeys", 0, -1)
     errors = []
     for error_key in error_keys:
@@ -1524,7 +1510,6 @@ def _init(address_info=None,
         Exception: An exception is raised if an inappropriate combination of
             arguments is passed in.
     """
-    check_main_thread()
     if driver_mode not in [SCRIPT_MODE, PYTHON_MODE, SILENT_MODE]:
         raise Exception("Driver_mode must be in [ray.SCRIPT_MODE, "
                         "ray.PYTHON_MODE, ray.SILENT_MODE].")
@@ -2054,7 +2039,6 @@ def connect(info,
         use_raylet: True if the new raylet code path should be used. This is
             not supported yet.
     """
-    check_main_thread()
     # Do some basic checking to make sure we didn't call ray.init twice.
     error_message = "Perhaps you called ray.init twice by accident?"
     assert not worker.connected, error_message
@@ -2092,8 +2076,9 @@ def connect(info,
 
     # Create a Redis client.
     redis_ip_address, redis_port = info["redis_address"].split(":")
-    worker.redis_client = redis.StrictRedis(
-        host=redis_ip_address, port=int(redis_port))
+    worker.redis_client = thread_safe_client(
+        redis.StrictRedis(host=redis_ip_address, port=int(redis_port))
+    )
 
     # For driver's check that the version information matches the version
     # information that the Ray cluster was started with.
@@ -2172,19 +2157,23 @@ def connect(info,
 
     # Create an object store client.
     if not worker.use_raylet:
-        worker.plasma_client = plasma.connect(info["store_socket_name"],
-                                              info["manager_socket_name"], 64)
+        worker.plasma_client = thread_safe_client(
+            plasma.connect(info["store_socket_name"], info["manager_socket_name"], 64)
+        )
     else:
-        worker.plasma_client = plasma.connect(info["store_socket_name"], "",
-                                              64)
+        worker.plasma_client = thread_safe_client(
+            plasma.connect(info["store_socket_name"], "", 64)
+        )
 
     if not worker.use_raylet:
         local_scheduler_socket = info["local_scheduler_socket_name"]
     else:
         local_scheduler_socket = info["raylet_socket_name"]
 
-    worker.local_scheduler_client = ray.local_scheduler.LocalSchedulerClient(
-        local_scheduler_socket, worker.worker_id, is_worker, worker.use_raylet)
+    worker.local_scheduler_client = thread_safe_client(
+        ray.local_scheduler.LocalSchedulerClient(
+            local_scheduler_socket, worker.worker_id, is_worker, worker.use_raylet)
+    )
 
     # If this is a driver, set the current task ID, the task driver ID, and set
     # the task index to 0.
@@ -2550,7 +2539,6 @@ def get(object_ids, worker=global_worker):
     """
     worker.check_connected()
     with log_span("ray:get", worker=worker):
-        check_main_thread()
 
         if worker.mode == PYTHON_MODE:
             # In PYTHON_MODE, ray.get is the identity operation (the input will
@@ -2583,8 +2571,6 @@ def put(value, worker=global_worker):
     """
     worker.check_connected()
     with log_span("ray:put", worker=worker):
-        check_main_thread()
-
         if worker.mode == PYTHON_MODE:
             # In PYTHON_MODE, ray.put is the identity operation.
             return value
@@ -2641,8 +2627,6 @@ def wait(object_ids, num_returns=1, timeout=None, worker=global_worker):
 
     worker.check_connected()
     with log_span("ray:wait", worker=worker):
-        check_main_thread()
-
         # When Ray is run in PYTHON_MODE, all functions are run immediately,
         # so all objects in object_id are ready.
         if worker.mode == PYTHON_MODE:

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1117,6 +1117,8 @@ class APITest(unittest.TestCase):
         def g(n):
             for _ in range(1000 // n):
                 ray.get([f.remote() for _ in range(n)])
+            res = [ray.put(i) for i in range(1000 // n)]
+            ray.wait(res, len(res))
 
         threads = [
             threading.Thread(target=g, args=(n, ))

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -1120,13 +1120,17 @@ class APITest(unittest.TestCase):
             res = [ray.put(i) for i in range(1000 // n)]
             ray.wait(res, len(res))
 
-        threads = [
-            threading.Thread(target=g, args=(n, ))
-            for n in [1, 5, 10, 100, 1000]
-        ]
+        @ray.remote
+        def multi_thread_worker():
+            threads = [
+                threading.Thread(target=g, args=(n, ))
+                for n in [1, 5, 10, 100, 1000]
+            ]
 
-        [thread.start() for thread in threads]
-        [thread.join() for thread in threads]
+            [thread.start() for thread in threads]
+            [thread.join() for thread in threads]
+
+        multi_thread_worker.remote()
 
 
 @unittest.skipIf(


### PR DESCRIPTION
Previously, Ray API isn't thread-safe and can only be called from the main thread.
This PR fixes the issue by simply locking all IO operations (redis_client/plasma_client/local_scheduler_client).
NOTE: the purpose of this RP is only to enable using Ray API in multiple threads, we'll need to make the locks smaller grained to achieve maximum performance.
TODO: make sure no perf regression when used in single thread. (What's the best way to benchmark this?)