### PR TITLE
[xray] Add Connect limitation to Object Manager.

### DIFF
--- a/src/common/state/ray_config.h
+++ b/src/common/state/ray_config.h
@@ -102,6 +102,10 @@ class RayConfig {
     return object_manager_max_receives_;
   }
 
+  uint32_t max_sender_connection_count() const {
+    return max_sender_connection_count_;
+  }
+
   uint64_t object_manager_default_chunk_size() const {
     return object_manager_default_chunk_size_;
   }
@@ -144,6 +148,7 @@ class RayConfig {
         object_manager_push_timeout_ms_(10000),
         object_manager_max_sends_(2),
         object_manager_max_receives_(2),
+        max_sender_connection_count_(5),
         object_manager_default_chunk_size_(100000000),
         num_workers_per_process_(1) {}
 
@@ -249,6 +254,11 @@ class RayConfig {
 
   /// Maximum number of concurrent receives allowed by the object manager.
   int object_manager_max_receives_;
+
+  /// The maximum sender connections allowed to a single Client.
+  /// 0: No limit on the sender connection.
+  /// Positive: the maximum number for sender connection.
+  uint32_t max_sender_connection_count_;
 
   /// Default chunk size for multi-chunk transfers to use in the object manager.
   /// In the object manager, no single thread is permitted to transfer more

--- a/src/ray/object_manager/connection_pool.cc
+++ b/src/ray/object_manager/connection_pool.cc
@@ -109,4 +109,12 @@ void ConnectionPool::Return(SenderMapType &conn_map, const ClientID &client_id,
   RAY_LOG(DEBUG) << "Return " << client_id << " " << conn_map[client_id].size();
 }
 
+uint64_t ConnectionPool::CountSender(ConnectionType type, const ClientID &client_id) {
+  std::unique_lock<std::mutex> guard(connection_mutex);
+  SenderMapType &conn_map = (type == ConnectionType::MESSAGE)
+                                ? message_send_connections_
+                                : transfer_send_connections_;
+  return Count(conn_map, client_id);
+}
+
 }  // namespace ray

--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -34,7 +34,7 @@ class ConnectionPool {
   enum class ConnectionType : int { MESSAGE = 0, TRANSFER };
 
   /// Connection pool for all connections needed by the ObjectManager.
-  ConnectionPool();
+  ConnectionPool(uint32_t max_sender_connection_count);
 
   /// Register a receiver connection.
   ///
@@ -88,8 +88,8 @@ class ConnectionPool {
   /// This object cannot be copied for thread-safety.
   RAY_DISALLOW_COPY_AND_ASSIGN(ConnectionPool);
 
-  /// Count the sender connections for target ConnectionType.
-  uint64_t CountSender(ConnectionType type, const ClientID &client_id);
+  /// Is it possible to add a new sender to connection pool.
+  bool CanAddSender(ConnectionType type, const ClientID &client_id);
 
  private:
   /// A container type that maps ClientID to a connection type.
@@ -133,6 +133,8 @@ class ConnectionPool {
 
   ReceiverMapType message_receive_connections_;
   ReceiverMapType transfer_receive_connections_;
+
+  uint32_t max_sender_connection_count;
 };
 
 }  // namespace ray

--- a/src/ray/object_manager/connection_pool.h
+++ b/src/ray/object_manager/connection_pool.h
@@ -88,6 +88,9 @@ class ConnectionPool {
   /// This object cannot be copied for thread-safety.
   RAY_DISALLOW_COPY_AND_ASSIGN(ConnectionPool);
 
+  /// Count the sender connections for target ConnectionType.
+  uint64_t CountSender(ConnectionType type, const ClientID &client_id);
+
  private:
   /// A container type that maps ClientID to a connection type.
   using SenderMapType =

--- a/src/ray/object_manager/object_manager.cc
+++ b/src/ray/object_manager/object_manager.cc
@@ -20,7 +20,7 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
                    /*release_delay=*/2 * config_.max_sends),
       send_work_(send_service_),
       receive_work_(receive_service_),
-      connection_pool_() {
+      connection_pool_(config_.max_sender_connection_count) {
   RAY_CHECK(config_.max_sends > 0);
   RAY_CHECK(config_.max_receives > 0);
   main_service_ = &main_service;
@@ -43,7 +43,7 @@ ObjectManager::ObjectManager(asio::io_service &main_service,
                    /*release_delay=*/2 * config_.max_sends),
       send_work_(send_service_),
       receive_work_(receive_service_),
-      connection_pool_() {
+      connection_pool_(config_.max_sender_connection_count) {
   RAY_CHECK(config_.max_sends > 0);
   RAY_CHECK(config_.max_receives > 0);
   // TODO(hme) Client ID is never set with this constructor.
@@ -168,41 +168,39 @@ ray::Status ObjectManager::PullEstablishConnection(const ObjectID &object_id,
   // Acquire a message connection and send pull request.
   ray::Status status;
   std::shared_ptr<SenderConnection> conn;
-  // TODO(hme): There is no cap on the number of pull request connections.
-  status = connection_pool_.GetSender(ConnectionPool::ConnectionType::MESSAGE, client_id,
-                                      &conn);
+  const ConnectionPool::ConnectionType connection_type =
+      ConnectionPool::ConnectionType::MESSAGE;
+  status = connection_pool_.GetSender(connection_type, client_id, &conn);
   // Currently, acquiring a connection should not fail.
   // No status from GetSender is returned which can be
   // handled without failing.
   RAY_CHECK_OK(status);
 
-  if (conn == nullptr) {
-    if (config_.max_sender_connection_count == 0 ||
-        connection_pool_.CountSender(ConnectionPool::ConnectionType::MESSAGE, client_id) <
-            config_.max_sender_connection_count) {
-      status = object_directory_->GetInformation(
-          client_id,
-          [this, object_id, client_id](const RemoteConnectionInfo &connection_info) {
-            std::shared_ptr<SenderConnection> async_conn = CreateSenderConnection(
-                ConnectionPool::ConnectionType::MESSAGE, connection_info);
-            connection_pool_.RegisterSender(ConnectionPool::ConnectionType::MESSAGE,
-                                            client_id, async_conn);
-            Status pull_send_status = PullSendRequest(object_id, async_conn);
-            RAY_CHECK_OK(pull_send_status);
-          },
-          [](const Status &status) {
-            RAY_LOG(ERROR)
-                << "Failed to establish connection with remote object manager.";
-            RAY_CHECK_OK(status);
-          });
-    } else {
-      // Cache this task until other tasks return the connection.
-      ObjectID copy_id = object_id;
-      message_tasks.AddTask(client_id, std::move(copy_id));
-    }
-  } else {
-    status = PullSendRequest(object_id, conn);
+  if (conn != nullptr) {
+    // To avoid nested if statements, an extra return statement is used here.
+    return PullSendRequest(object_id, conn);
   }
+  // Connection is empty. Need to checkout whether we can add a new connection.
+  if (connection_pool_.CanAddSender(connection_type, client_id)) {
+    status = object_directory_->GetInformation(
+        client_id,
+        [this, object_id, client_id](const RemoteConnectionInfo &connection_info) {
+          std::shared_ptr<SenderConnection> async_conn =
+              CreateSenderConnection(connection_type, connection_info);
+          connection_pool_.RegisterSender(connection_type, client_id, async_conn);
+          Status pull_send_status = PullSendRequest(object_id, async_conn);
+          RAY_CHECK_OK(pull_send_status);
+        },
+        [](const Status &status) {
+          RAY_LOG(ERROR) << "Failed to establish connection with remote object manager.";
+          RAY_CHECK_OK(status);
+        });
+  } else {
+    // Cache this task until other tasks return the connection.
+    ObjectID copy_id = object_id;
+    message_tasks.AddTask(client_id, copy_id);
+  }
+
   return status;
 }
 
@@ -306,20 +304,18 @@ void ObjectManager::ExecuteSendObject(const ClientID &client_id,
                  << chunk_index;
   ray::Status status;
   std::shared_ptr<SenderConnection> conn;
-  status = connection_pool_.GetSender(ConnectionPool::ConnectionType::TRANSFER, client_id,
-                                      &conn);
+  const ConnectionPool::ConnectionType connection_type =
+      ConnectionPool::ConnectionType::TRANSFER;
+  status = connection_pool_.GetSender(connection_type, client_id, &conn);
+
   if (conn == nullptr) {
-    if (config_.max_sender_connection_count == 0 ||
-        connection_pool_.CountSender(ConnectionPool::ConnectionType::TRANSFER,
-                                     client_id) < config_.max_sender_connection_count) {
-      conn = CreateSenderConnection(ConnectionPool::ConnectionType::TRANSFER,
-                                    connection_info);
-      connection_pool_.RegisterSender(ConnectionPool::ConnectionType::TRANSFER, client_id,
-                                      conn);
+    if (connection_pool_.CanAddSender(connection_type, client_id)) {
+      conn = CreateSenderConnection(connection_type, connection_info);
+      connection_pool_.RegisterSender(connection_type, client_id, conn);
     } else {
-      // Cache this task until other tasks return the connection.
+      // Cache this task until other connections are available.
       ObjectTransferTask save_task(object_id, data_size, metadata_size, chunk_index);
-      transfer_tasks.AddTask(client_id, std::move(save_task));
+      transfer_tasks.AddTask(client_id, save_task);
       return;
     }
   }

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -260,12 +260,12 @@ class ObjectManager : public ObjectManagerInterface {
    private:
     std::mutex mutex;
 
-    std::unordered_map<ClientID, std::list<T>> cached_tasks;
+    std::unordered_map<ClientID, std::deque<T>> cached_tasks;
 
    public:
-    void AddTask(const ClientID &client_id, T &&task) {
+    void AddTask(const ClientID &client_id, T &task) {
       std::unique_lock<std::mutex> guard(mutex);
-      cached_tasks[client_id].emplace_back(std::move(task));
+      cached_tasks[client_id].emplace_back(task);
     }
 
     bool PopTask(const ClientID &client_id, T &task) {
@@ -273,7 +273,7 @@ class ObjectManager : public ObjectManagerInterface {
       auto iter = cached_tasks.find(client_id);
       if (iter != cached_tasks.end()) {
         RAY_CHECK(iter->second.size() > 0);
-        task = std::move(iter->second.front());
+        task = iter->second.front();
         iter->second.pop_front();
         if (iter->second.empty()) {
           cached_tasks.erase(iter);

--- a/src/ray/object_manager/object_manager.h
+++ b/src/ray/object_manager/object_manager.h
@@ -46,6 +46,10 @@ struct ObjectManagerConfig {
   /// Negative: waiting infinitely.
   /// 0: giving up retrying immediately.
   int push_timeout_ms;
+  /// The maximum sender connections allowed to a single Client.
+  /// 0: No limit on the sender connection.
+  /// Positive: the maximum number for sender connection.
+  uint32_t max_sender_connection_count;
 };
 
 class ObjectManagerInterface {
@@ -231,6 +235,59 @@ class ObjectManager : public ObjectManagerInterface {
 
   /// A set of active wait requests.
   std::unordered_map<UniqueID, WaitState> active_wait_requests_;
+
+  /// The cached Object transfer task due to maximum connect reached.
+  struct ObjectTransferTask {
+    ObjectID object_id;
+
+    int64_t data_size;
+
+    int64_t metadata_size;
+
+    int64_t chunk_index;
+
+    ObjectTransferTask(ObjectID object_id_, int data_size_, int64_t metadata_size_,
+                       int64_t chunk_index_)
+        : object_id(object_id_),
+          data_size(data_size_),
+          metadata_size(metadata_size_),
+          chunk_index(chunk_index_) {}
+    ObjectTransferTask() {}
+  };
+
+  template <typename T>
+  class SendingTaskPool {
+   private:
+    std::mutex mutex;
+
+    std::unordered_map<ClientID, std::list<T>> cached_tasks;
+
+   public:
+    void AddTask(const ClientID &client_id, T &&task) {
+      std::unique_lock<std::mutex> guard(mutex);
+      cached_tasks[client_id].emplace_back(std::move(task));
+    }
+
+    bool PopTask(const ClientID &client_id, T &task) {
+      std::unique_lock<std::mutex> guard(mutex);
+      auto iter = cached_tasks.find(client_id);
+      if (iter != cached_tasks.end()) {
+        RAY_CHECK(iter->second.size() > 0);
+        task = std::move(iter->second.front());
+        iter->second.pop_front();
+        if (iter->second.empty()) {
+          cached_tasks.erase(iter);
+        }
+        return true;
+      }
+      return false;
+    }
+  };
+
+  /// List of pending Object Transfering task.
+  SendingTaskPool<ObjectTransferTask> transfer_tasks;
+  /// List of pending Message task.
+  SendingTaskPool<ObjectID> message_tasks;
 
   /// Creates a wait request and adds it to active_wait_requests_.
   ray::Status AddWaitRequest(const UniqueID &wait_id,

--- a/src/ray/object_manager/test/object_manager_stress_test.cc
+++ b/src/ray/object_manager/test/object_manager_stress_test.cc
@@ -125,6 +125,7 @@ class TestObjectManagerBase : public ::testing::Test {
     int max_receives = 2;
     uint64_t object_chunk_size = static_cast<uint64_t>(std::pow(10, 3));
     int push_timeout_ms = 10000;
+    uint32_t max_sender_connection_count = 5;
 
     // start first server
     gcs_client_1 = std::shared_ptr<gcs::AsyncGcsClient>(new gcs::AsyncGcsClient());
@@ -135,6 +136,7 @@ class TestObjectManagerBase : public ::testing::Test {
     om_config_1.max_receives = max_receives;
     om_config_1.object_chunk_size = object_chunk_size;
     om_config_1.push_timeout_ms = push_timeout_ms;
+    om_config_1.max_sender_connection_count = max_sender_connection_count;
     server1.reset(new MockServer(main_service, om_config_1, gcs_client_1));
 
     // start second server
@@ -146,6 +148,7 @@ class TestObjectManagerBase : public ::testing::Test {
     om_config_2.max_receives = max_receives;
     om_config_2.object_chunk_size = object_chunk_size;
     om_config_2.push_timeout_ms = push_timeout_ms;
+    om_config_2.max_sender_connection_count = max_sender_connection_count;
     server2.reset(new MockServer(main_service, om_config_2, gcs_client_2));
 
     // connect to stores.

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -61,6 +61,8 @@ int main(int argc, char *argv[]) {
       RayConfig::instance().object_manager_push_timeout_ms();
   object_manager_config.object_chunk_size =
       RayConfig::instance().object_manager_default_chunk_size();
+  object_manager_config.max_sender_connection_count =
+      RayConfig::instance().max_sender_connection_count();
 
   //  initialize mock gcs & object directory
   auto gcs_client = std::make_shared<ray::gcs::AsyncGcsClient>();

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -57,6 +57,7 @@ class TestObjectManagerBase : public ::testing::Test {
     ObjectManagerConfig om_config_1;
     om_config_1.store_socket_name = store_sock_1;
     om_config_1.push_timeout_ms = 10000;
+    om_config_1.max_sender_connection_count = 5;
     server1.reset(new ray::raylet::Raylet(
         main_service, "raylet_1", "0.0.0.0", "127.0.0.1", 6379,
         GetNodeManagerConfig("raylet_1", store_sock_1), om_config_1, gcs_client_1));
@@ -66,6 +67,7 @@ class TestObjectManagerBase : public ::testing::Test {
     ObjectManagerConfig om_config_2;
     om_config_2.store_socket_name = store_sock_2;
     om_config_2.push_timeout_ms = 10000;
+    om_config_2.max_sender_connection_count = 5;
     server2.reset(new ray::raylet::Raylet(
         main_service, "raylet_2", "0.0.0.0", "127.0.0.1", 6379,
         GetNodeManagerConfig("raylet_2", store_sock_2), om_config_2, gcs_client_2));


### PR DESCRIPTION

## What do these changes do?
<!-- Please give a short brief about these changes. -->
There is no limitation on Sender Connectios. At the extreme situation, the object manager open large amount of connections to other object managers.

This code change add a limitation on the Sender Connection number. Since the sender/receiver are a pair, the Receiver Connection can also be restricted at the same time. If we use `max_sender_connection_count = 0`, that means there is no limitation the same as the current case.

## Related issue number

<!-- Are there any issues opened that will be resolved by merging this change? -->
N/A
## Explanation
1. The unsatisfied sending tasks will be put to a pool. 
2. When a sending task is finished and before it returns the connection to connection_pool, the task will check the task pool. Therefore, no timer is needed to handle this pool. 
3. There are multiple send/receive threads, so a lock is necessary in the pool. 
4. As long as the connection is released on time, the AddTask function will not be triggered, which has less perf concerns in normal cases.
5. Stress Test Time (Baseline vs. Change): Round1: 2414ms vs. 2395ms; Round2: 2405ms vs. 2412ms. 