### PR TITLE
Mitigate randomly building failure. Issue 2257

### DIFF
--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -77,6 +77,6 @@ install(
 
 ADD_RAY_LIB(ray
   SOURCES ${RAY_SRCS} ${AE_SRCS} ${HIREDIS_SRCS} ${UTIL_SRCS}
-    DEPENDENCIES gen_gcs_fbs gen_object_manager_fbs gen_node_manager_fbs
+    DEPENDENCIES gen_gcs_fbs gen_object_manager_fbs gen_node_manager_fbs gen_local_scheduler_fbs
     SHARED_LINK_LIBS ""
     STATIC_LINK_LIBS ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB})


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Add the dependency gen_local_scheduler_fbs to raylet to mitigate the random building fail (issue 2257). 
## Explanation
Raylet is designed to replace the old ray backend, so gen_local_scheduler_fbs should not be added to rayley dependency. However, currently, raylet is in the way to replace old ray backend.  node_manager.cc has included local_scheduler_generated.h to guarantee the enum consistency. If this dependency is not added, it is not guaranteed that gen_local_scheduler_fbs will build ahead of raylet lib and the building process will fail randomly. 

The final solution is to retire the old ray backed, but now we need to add this dependency.
<!-- Please give a short brief about these changes. -->

## Related issue number
2257
2185
<!-- Are there any issues opened that will be resolved by merging this change? -->
