### PR TITLE
Fix build failure while using `make -j1`. Issue 2257 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -97,6 +97,9 @@ if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
   add_custom_target(copy_ray ALL
       DEPENDS ${build_ray_file_list})
 
+  # Make sure redis-server is ready before copying.
+  add_dependencies(copy_ray copy_redis)
+
   # Make sure that the Python extensions are built before copying the files.
   if ("${CMAKE_RAY_LANG_PYTHON}" STREQUAL "YES")
     get_local_scheduler_library("python" LOCAL_SCHEDULER_LIBRARY_LANG)

--- a/src/global_scheduler/CMakeLists.txt
+++ b/src/global_scheduler/CMakeLists.txt
@@ -7,4 +7,8 @@ include(${CMAKE_CURRENT_LIST_DIR}/../common/cmake/Common.cmake)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Werror -Wall")
 
 add_executable(global_scheduler global_scheduler.cc global_scheduler_algorithm.cc)
+
+# Make sure ${HIREDIS_LIB} is ready before linking.
+add_dependencies(global_scheduler hiredis)
+
 target_link_libraries(global_scheduler common ${HIREDIS_LIB} ray_static ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB} ${Boost_SYSTEM_LIBRARY} pthread)

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -62,7 +62,7 @@ add_dependencies(gen_local_scheduler_fbs flatbuffers_ep)
 add_library(local_scheduler_client STATIC local_scheduler_client.cc)
 
 # local_scheduler_shared.h includes ray/gcs/client.h which requires gen_gcs_fbs & gen_node_manager_fbs.
-add_dependencies(local_scheduler_client gen_local_scheduler_fbs gen_common_python_fbs gen_gcs_fbs gen_node_manager_fbs)
+add_dependencies(local_scheduler_client gen_local_scheduler_fbs ${COMMON_FBS_OUTPUT_FILES} gen_gcs_fbs gen_node_manager_fbs)
 
 add_executable(local_scheduler local_scheduler.cc local_scheduler_algorithm.cc)
 target_link_libraries(local_scheduler local_scheduler_client common ${HIREDIS_LIB} ${PLASMA_STATIC_LIB} ray_static ${ARROW_STATIC_LIB} -lpthread ${Boost_SYSTEM_LIBRARY})

--- a/src/local_scheduler/CMakeLists.txt
+++ b/src/local_scheduler/CMakeLists.txt
@@ -61,7 +61,8 @@ add_dependencies(gen_local_scheduler_fbs flatbuffers_ep)
 
 add_library(local_scheduler_client STATIC local_scheduler_client.cc)
 
-add_dependencies(local_scheduler_client gen_local_scheduler_fbs)
+# local_scheduler_shared.h includes ray/gcs/client.h which requires gen_gcs_fbs & gen_node_manager_fbs.
+add_dependencies(local_scheduler_client gen_local_scheduler_fbs gen_common_python_fbs gen_gcs_fbs gen_node_manager_fbs)
 
 add_executable(local_scheduler local_scheduler.cc local_scheduler_algorithm.cc)
 target_link_libraries(local_scheduler local_scheduler_client common ${HIREDIS_LIB} ${PLASMA_STATIC_LIB} ray_static ${ARROW_STATIC_LIB} -lpthread ${Boost_SYSTEM_LIBRARY})

--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -79,6 +79,6 @@ ADD_RAY_LIB(ray
   SOURCES ${RAY_SRCS} ${AE_SRCS} ${HIREDIS_SRCS} ${UTIL_SRCS}
     # TODO: When raylet replaces the old backend, please remove the dependency gen_local_scheduler_fbs.
     # TODO: When remove the included Task.h from table.h, please remove the dependency gen_common_python_fbs.
-    DEPENDENCIES gen_gcs_fbs gen_object_manager_fbs gen_node_manager_fbs gen_local_scheduler_fbs gen_common_python_fbs
+    DEPENDENCIES gen_gcs_fbs gen_object_manager_fbs gen_node_manager_fbs gen_local_scheduler_fbs ${COMMON_FBS_OUTPUT_FILES}
     SHARED_LINK_LIBS ""
     STATIC_LINK_LIBS ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB})

--- a/src/ray/CMakeLists.txt
+++ b/src/ray/CMakeLists.txt
@@ -77,6 +77,8 @@ install(
 
 ADD_RAY_LIB(ray
   SOURCES ${RAY_SRCS} ${AE_SRCS} ${HIREDIS_SRCS} ${UTIL_SRCS}
-    DEPENDENCIES gen_gcs_fbs gen_object_manager_fbs gen_node_manager_fbs gen_local_scheduler_fbs
+    # TODO: When raylet replaces the old backend, please remove the dependency gen_local_scheduler_fbs.
+    # TODO: When remove the included Task.h from table.h, please remove the dependency gen_common_python_fbs.
+    DEPENDENCIES gen_gcs_fbs gen_object_manager_fbs gen_node_manager_fbs gen_local_scheduler_fbs gen_common_python_fbs
     SHARED_LINK_LIBS ""
     STATIC_LINK_LIBS ${PLASMA_STATIC_LIB} ${ARROW_STATIC_LIB})

--- a/src/ray/gcs/tables.h
+++ b/src/ray/gcs/tables.h
@@ -15,6 +15,8 @@
 #include "ray/raylet/format/node_manager_generated.h"
 
 // TODO(pcm): Remove this
+// TODO: While removing "task.h", remove the dependency gen_common_python_fbs
+//       from src/ray/CMakeLists.txt.
 #include "task.h"
 
 struct redisAsyncContext;

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1,6 +1,8 @@
 #include "ray/raylet/node_manager.h"
 
 #include "common_protocol.h"
+// TODO: While removing "local_scheduler_generated.h", remove the dependency
+//       gen_local_scheduler_fbs from src/ray/CMakeLists.txt.
 #include "local_scheduler/format/local_scheduler_generated.h"
 #include "ray/raylet/format/node_manager_generated.h"
 

--- a/thirdparty/scripts/setup.sh
+++ b/thirdparty/scripts/setup.sh
@@ -27,6 +27,11 @@ echo "Build language is $LANGUAGE."
 unamestr="$(uname)"
 
 ##############################################
+# boost
+##############################################
+bash "$TP_SCRIPT_DIR/build_boost.sh"
+
+##############################################
 # redis
 ##############################################
 bash "$TP_SCRIPT_DIR/build_redis.sh"
@@ -35,11 +40,6 @@ bash "$TP_SCRIPT_DIR/build_redis.sh"
 # credis
 ##############################################
 bash "$TP_SCRIPT_DIR/build_credis.sh"
-
-##############################################
-# boost
-##############################################
-bash "$TP_SCRIPT_DIR/build_boost.sh"
 
 ##############################################
 # flatbuffers if necessary


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
I compared the build log provided by Issue 2257. The setting is `make -j1`. In most cases, we use multi-thread,  so some missing dependencies will not be a problem since other threads may finish building the dependency in time. 
This change fix all the missing dependencies and now we can build ray with `make -j1`.
<!-- Please give a short brief about these changes. -->

## Related issue number
2257
<!-- Are there any issues opened that will be resolved by merging this change? -->
