### PR TITLE
[Issue 2222] Provide better API method for dumping the task timeline …

### DIFF
--- a/python/ray/experimental/state.py
+++ b/python/ray/experimental/state.py
@@ -1191,3 +1191,19 @@ class GlobalState(object):
             binary_to_hex(job_id): self._error_messages(ray.ObjectID(job_id))
             for job_id in job_ids
         }
+
+    def dump_task_timeline(self, file_name, num_tasks, start=None, end=None, fwd=True):
+        """Fetch a number of task profiles and dump them to a file
+
+        Args:
+            path: The filepath to dump the profiling information to.
+            num_tasks: A limit on the number of tasks that task_profiles will return.
+            start: The start point of the time window that is queried for tasks.
+            end: The end point in time of the time window that is queried for tasks.
+            fwd: If True, means that zrange will be used. If False, zrevrange.
+                This argument is only meaningful in conjunction with the
+                num_tasks argument. This controls whether the tasks returned
+                are the most recent or the least recent.
+        """
+        task_info = self.task_profiles(num_tasks, start, end, fwd)
+        self.dump_catapult_trace(file_name, task_info)

--- a/test/runtest.py
+++ b/test/runtest.py
@@ -2295,9 +2295,7 @@ class GlobalStateAPI(unittest.TestCase):
         ray.get([actor.method.remote() for actor in actors])
 
         path = os.path.join("/tmp/ray_test_trace")
-        task_info = ray.global_state.task_profiles(
-            100, start=0, end=time.time())
-        ray.global_state.dump_catapult_trace(path, task_info)
+        ray.global_state.dump_task_timeline(path, 100, start=0, end=time.time())
 
         # TODO(rkn): This test is not perfect because it does not verify that
         # the visualization actually renders (e.g., the context of the dumped


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Provide an easier way to dump the task profiles.
<!-- Please give a short brief about these changes. -->

## Related issue number
2222
<!-- Are there any issues opened that will be resolved by merging this change? -->
