### PR TITLE
Use ser context map

### DIFF
--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -231,6 +231,18 @@ class Worker(object):
         # When the worker is constructed. Record the original value of the
         # CUDA_VISIBLE_DEVICES environment variable.
         self.original_gpu_ids = ray.utils.get_cuda_visible_devices()
+        # A dictionary that maps from driver id to SerializationContext
+        # TODO: clean up the SerializationContext once the job finished.
+        self.serialization_context_map = dict()
+        # Identity of the driver that this worker is processing.
+        self.task_driver_id = None
+
+    def get_serialization_context(self):
+        """Get the SerializationContext of the driver that this worker is processing
+        """
+        if self.task_driver_id not in self.serialization_context_map:
+            _initialize_serialization()
+        return self.serialization_context_map[self.task_driver_id]
 
     def check_connected(self):
         """Check if the worker is connected.
@@ -294,7 +306,7 @@ class Worker(object):
                     value,
                     object_id=pyarrow.plasma.ObjectID(object_id.id()),
                     memcopy_threads=self.memcopy_threads,
-                    serialization_context=self.serialization_context)
+                    serialization_context=self.get_serialization_context())
                 break
             except pyarrow.SerializationCallbackError as e:
                 try:
@@ -385,7 +397,7 @@ class Worker(object):
                     results += self.plasma_client.get(
                         object_ids[i:(
                             i + ray._config.worker_get_request_size())],
-                        timeout, self.serialization_context)
+                        timeout, self.get_serialization_context())
                 return results
             except pyarrow.lib.ArrowInvalid as e:
                 # TODO(ekl): the local scheduler could include relevant
@@ -1224,11 +1236,11 @@ def _initialize_serialization(worker=global_worker):
     This defines a custom serializer for object IDs and also tells ray to
     serialize several exception classes that we define for error handling.
     """
-    worker.serialization_context = pyarrow.default_serialization_context()
+    worker.serialization_context_map[worker.task_driver_id] = pyarrow.default_serialization_context()
     # Tell the serialization context to use the cloudpickle version that we
     # ship with Ray.
-    worker.serialization_context.set_pickle(pickle.dumps, pickle.loads)
-    pyarrow.register_torch_serialization_handlers(worker.serialization_context)
+    worker.serialization_context_map[worker.task_driver_id].set_pickle(pickle.dumps, pickle.loads)
+    pyarrow.register_torch_serialization_handlers(worker.serialization_context_map[worker.task_driver_id])
 
     # Define a custom serializer and deserializer for handling Object IDs.
     def object_id_custom_serializer(obj):
@@ -1240,7 +1252,7 @@ def _initialize_serialization(worker=global_worker):
     # We register this serializer on each worker instead of calling
     # register_custom_serializer from the driver so that isinstance still
     # works.
-    worker.serialization_context.register_type(
+    worker.serialization_context_map[worker.task_driver_id].register_type(
         ray.ObjectID,
         "ray.ObjectID",
         pickle=False,
@@ -1258,7 +1270,7 @@ def _initialize_serialization(worker=global_worker):
     # We register this serializer on each worker instead of calling
     # register_custom_serializer from the driver so that isinstance still
     # works.
-    worker.serialization_context.register_type(
+    worker.serialization_context_map[worker.task_driver_id].register_type(
         ray.actor.ActorHandle,
         "ray.ActorHandle",
         pickle=False,
@@ -2393,7 +2405,7 @@ def disconnect(worker=global_worker):
     worker.connected = False
     worker.cached_functions_to_run = []
     worker.cached_remote_functions_and_actors = []
-    worker.serialization_context = pyarrow.SerializationContext()
+    worker.serialization_context_map[worker.task_driver_id] = pyarrow.SerializationContext()
 
 
 def _try_to_compute_deterministic_class_id(cls, depth=5):
@@ -2510,7 +2522,7 @@ def register_custom_serializer(cls,
         # we may want to use the last user-defined serializers and ignore
         # subsequent calls to register_custom_serializer that were made by the
         # system.
-        worker_info["worker"].serialization_context.register_type(
+        worker_info["worker"].get_serialization_context().register_type(
             cls,
             class_id,
             pickle=use_pickle,


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
Previously, a worker used shared SerializationContext for different drivers. That caused problems in this case: worker already have callback info for a type kept in shared context (from the former drivers) but the new driver doesn't. Since the worker knows that info so it won't publish again. 
In this change, we make a map (from driver id to SerializationContext) inside worker, so each driver will has its own SerializationContext.
<!-- Please give a short brief about these changes. -->

## Related issue number
[2165](https://github.com/ray-project/ray/issues/2165)
<!-- Are there any issues opened that will be resolved by merging this change? -->
