### PR TITLE
[java worker] Problem of put perf

### DIFF
--- a/thirdparty/scripts/build_arrow.sh
+++ b/thirdparty/scripts/build_arrow.sh
@@ -53,7 +53,7 @@ if [[ ! -d $TP_DIR/../python/ray/pyarrow_files/pyarrow ]]; then
     # The PR for this commit is https://github.com/apache/arrow/pull/2065. We
     # include the link here to make it easier to find the right commit because
     # Arrow often rewrites git history and invalidates certain commits.
-    git checkout ce23c06469de9cf0c3e38e35cdb8d135f341b964
+    git checkout 6df28d35711ec15e56b4cd2428036964c25e296d
 
     cd cpp
     if [ ! -d "build" ]; then


### PR DESCRIPTION


## What do these changes do?
_This_ PR is to discuss a java worker perf problem, as no issue tab is provided._
Now, I am doing perf test about plasma queue, and I compare it with original method(like `put` in java worker), but I find when calling `put` many times continuously, it will become slower and slower. The test is as below.
`for (int i = 0; i<100000; i=i+1) {
        Ray.put(i);
        if (i % 10000 == 0) {
          String timeStamp = new SimpleDateFormat("yyyy.MM.dd.HH.mm.ss.SSS").format(new Date());
          RayLog.rapp.info("put obj: "+ Integer.toString(i) + ": " + timeStamp);
        }
      }`

and the output is as below.

![image](https://user-images.githubusercontent.com/9260628/42268867-36eb059c-7faf-11e8-847f-f5d56023c738.png)

I have tied to find the cause.
 When using test in arrow/java/plasma [https://github.com/eric-jj/arrow/blob/147ae2f05bb0be8d646ce4ad15f73e7909ca24b2/java/plasma/src/test/java/org/apache/arrow/plasma/PlasmaClientTest.java#L173](url), the problem doesn't appear. 
I also remove the java serialize and use a simple byte[], it seems serialization is not relevant.

So what's the reason?
