### PR TITLE
Make local scheduler client thread-safe

### DIFF
--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -251,7 +251,7 @@ int write_bytes(int fd, uint8_t *cursor, size_t length) {
   return 0;
 }
 
-int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
+int _write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
   int64_t version = RayConfig::instance().ray_protocol_version();
   int closed;
   closed = write_bytes(fd, (uint8_t *) &version, sizeof(version));
@@ -271,6 +271,17 @@ int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
     return closed;
   }
   return 0;
+}
+
+int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes,
+    std::mutex *mutex) {
+  if (mutex != NULL) {
+    std::unique_lock<std::mutex> guard(*mutex);
+    return _write_message(fd, type, length, bytes);
+  }
+  else{
+    return _write_message(fd, type, length, bytes);
+  }
 }
 
 int read_bytes(int fd, uint8_t *cursor, size_t length) {
@@ -388,7 +399,7 @@ disconnected:
 
 void write_log_message(int fd, const char *message) {
   /* Account for the \0 at the end of the string. */
-  write_message(fd, static_cast<int64_t>(CommonMessageType::LOG_MESSAGE),
+  _write_message(fd, static_cast<int64_t>(CommonMessageType::LOG_MESSAGE),
                 strlen(message) + 1, (uint8_t *) message);
 }
 

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -273,13 +273,15 @@ int _write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
   return 0;
 }
 
-int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes,
-    std::mutex *mutex) {
+int write_message(int fd,
+                  int64_t type,
+                  int64_t length,
+                  uint8_t *bytes,
+                  std::mutex *mutex) {
   if (mutex != NULL) {
     std::unique_lock<std::mutex> guard(*mutex);
     return _write_message(fd, type, length, bytes);
-  }
-  else{
+  } else {
     return _write_message(fd, type, length, bytes);
   }
 }
@@ -400,7 +402,7 @@ disconnected:
 void write_log_message(int fd, const char *message) {
   /* Account for the \0 at the end of the string. */
   _write_message(fd, static_cast<int64_t>(CommonMessageType::LOG_MESSAGE),
-                strlen(message) + 1, (uint8_t *) message);
+                 strlen(message) + 1, (uint8_t *) message);
 }
 
 char *read_log_message(int fd) {

--- a/src/common/io.cc
+++ b/src/common/io.cc
@@ -251,7 +251,7 @@ int write_bytes(int fd, uint8_t *cursor, size_t length) {
   return 0;
 }
 
-int _write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
+int do_write_message(int fd, int64_t type, int64_t length, uint8_t *bytes) {
   int64_t version = RayConfig::instance().ray_protocol_version();
   int closed;
   closed = write_bytes(fd, (uint8_t *) &version, sizeof(version));
@@ -280,9 +280,9 @@ int write_message(int fd,
                   std::mutex *mutex) {
   if (mutex != NULL) {
     std::unique_lock<std::mutex> guard(*mutex);
-    return _write_message(fd, type, length, bytes);
+    return do_write_message(fd, type, length, bytes);
   } else {
-    return _write_message(fd, type, length, bytes);
+    return do_write_message(fd, type, length, bytes);
   }
 }
 
@@ -401,8 +401,8 @@ disconnected:
 
 void write_log_message(int fd, const char *message) {
   /* Account for the \0 at the end of the string. */
-  _write_message(fd, static_cast<int64_t>(CommonMessageType::LOG_MESSAGE),
-                 strlen(message) + 1, (uint8_t *) message);
+  do_write_message(fd, static_cast<int64_t>(CommonMessageType::LOG_MESSAGE),
+                   strlen(message) + 1, (uint8_t *) message);
 }
 
 char *read_log_message(int fd) {

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
+#include <mutex>
 #include <vector>
 
 struct aeEventLoop;
@@ -121,10 +122,13 @@ int accept_client(int socket_fd);
  * @param type The type of the message to send.
  * @param length The size in bytes of the bytes parameter.
  * @param bytes The address of the message to send.
+ * @param mutex If not NULL, the whole write operation will be locked
+ *        with this mutex, otherwise do nothing.
  * @return int Whether there was an error while writing. 0 corresponds to
  *         success and -1 corresponds to an error (errno will be set).
  */
-int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes);
+int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes,
+    std::mutex *mutex=NULL);
 
 /**
  * Read a sequence of bytes written by write_message from a file descriptor.

--- a/src/common/io.h
+++ b/src/common/io.h
@@ -127,8 +127,11 @@ int accept_client(int socket_fd);
  * @return int Whether there was an error while writing. 0 corresponds to
  *         success and -1 corresponds to an error (errno will be set).
  */
-int write_message(int fd, int64_t type, int64_t length, uint8_t *bytes,
-    std::mutex *mutex=NULL);
+int write_message(int fd,
+                  int64_t type,
+                  int64_t length,
+                  uint8_t *bytes,
+                  std::mutex *mutex = NULL);
 
 /**
  * Read a sequence of bytes written by write_message from a file descriptor.

--- a/src/local_scheduler/lib/python/local_scheduler_extension.cc
+++ b/src/local_scheduler/lib/python/local_scheduler_extension.cc
@@ -267,11 +267,13 @@ static PyObject *PyLocalSchedulerClient_wait(PyObject *self, PyObject *args) {
   }
 
   // Invoke wait.
+  Py_BEGIN_ALLOW_THREADS
   std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result =
       local_scheduler_wait(reinterpret_cast<PyLocalSchedulerClient *>(self)
                                ->local_scheduler_connection,
                            object_ids, num_returns, timeout_ms,
                            static_cast<bool>(wait_local));
+  Py_END_ALLOW_THREADS
 
   // Convert result to py object.
   PyObject *py_found = PyList_New(static_cast<Py_ssize_t>(result.first.size()));

--- a/src/local_scheduler/lib/python/local_scheduler_extension.cc
+++ b/src/local_scheduler/lib/python/local_scheduler_extension.cc
@@ -267,13 +267,11 @@ static PyObject *PyLocalSchedulerClient_wait(PyObject *self, PyObject *args) {
   }
 
   // Invoke wait.
-  Py_BEGIN_ALLOW_THREADS
   std::pair<std::vector<ObjectID>, std::vector<ObjectID>> result =
       local_scheduler_wait(reinterpret_cast<PyLocalSchedulerClient *>(self)
                                ->local_scheduler_connection,
                            object_ids, num_returns, timeout_ms,
                            static_cast<bool>(wait_local));
-  Py_END_ALLOW_THREADS
 
   // Convert result to py object.
   PyObject *py_found = PyList_New(static_cast<Py_ssize_t>(result.first.size()));

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -1,6 +1,8 @@
 #ifndef LOCAL_SCHEDULER_CLIENT_H
 #define LOCAL_SCHEDULER_CLIENT_H
 
+#include <mutex>
+
 #include "common/task.h"
 #include "local_scheduler_shared.h"
 #include "ray/raylet/task_spec.h"
@@ -21,6 +23,8 @@ struct LocalSchedulerConnection {
       resource_ids_;
   /// A mutex to protect stateful operations of the local scheduler client.
   std::mutex mutex;
+  /// A mutext to protect write operations of the local scheduler client.
+  std::mutex write_mutex;
 };
 
 /**

--- a/src/local_scheduler/local_scheduler_client.h
+++ b/src/local_scheduler/local_scheduler_client.h
@@ -19,6 +19,8 @@ struct LocalSchedulerConnection {
   /// of that resource allocated for this worker.
   std::unordered_map<std::string, std::vector<std::pair<int64_t, double>>>
       resource_ids_;
+  /// A mutex to protect stateful operations of the local scheduler client.
+  std::mutex mutex;
 };
 
 /**


### PR DESCRIPTION
This PR makes local scheduler client thread-safe by adding 2 locks:
1) the 'write_mutex' is used to avoid multiple threads writing to the connection simultaneously.
2) since the reads are always used together with writes, and makes the whole process transactional, another 'mutex' is used to make the these processes atomic.

Perf impact is negligible:
```
Benchmark: https://gist.github.com/raulchen/2c315cbd4d2387bf356adbe2a8641986#file-gistfile1-txt

With this PR:
test_put_and_get: Avg: 235.28, Min: 209.41, Max: 429.16, P50: 227.32, P90: 268.50
test_remote: Avg: 149.50, Min: 61.84, Max: 279.36, P50: 150.31, P90: 191.73

Without this PR:
test_put_and_get: Avg: 259.65, Min: 218.51, Max: 420.26, P50: 258.75, P90: 280.03
test_remote: Avg: 146.55, Min: 85.89, Max: 249.83, P50: 144.64, P90: 180.68
```