### PR TITLE
move profiling code to a new file and fix thread safety

### DIFF
--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -65,11 +65,10 @@ __version__ = "0.5.0"
 
 __all__ = [
     "error_info", "init", "connect", "disconnect", "get", "put", "wait",
-    "remote", "profile", "actor", "method",
-    "get_gpu_ids", "get_resource_ids", "get_webui_url",
-    "register_custom_serializer", "shutdown", "SCRIPT_MODE", "WORKER_MODE",
-    "LOCAL_MODE", "SILENT_MODE", "global_state", "ObjectID", "_config",
-    "__version__"
+    "remote", "profile", "actor", "method", "get_gpu_ids", "get_resource_ids",
+    "get_webui_url", "register_custom_serializer", "shutdown", "SCRIPT_MODE",
+    "WORKER_MODE", "LOCAL_MODE", "SILENT_MODE", "global_state", "ObjectID",
+    "_config", "__version__"
 ]
 
 import ctypes  # noqa: E402

--- a/python/ray/__init__.py
+++ b/python/ray/__init__.py
@@ -47,9 +47,9 @@ except ImportError as e:
     raise
 
 from ray.local_scheduler import ObjectID, _config  # noqa: E402
+from ray.profiling import profile  # noqa: E402
 from ray.worker import (error_info, init, connect, disconnect, get, put, wait,
-                        remote, profile, flush_profile_data, get_gpu_ids,
-                        get_resource_ids, get_webui_url,
+                        remote, get_gpu_ids, get_resource_ids, get_webui_url,
                         register_custom_serializer, shutdown)  # noqa: E402
 from ray.worker import (SCRIPT_MODE, WORKER_MODE, LOCAL_MODE,
                         SILENT_MODE)  # noqa: E402
@@ -65,7 +65,7 @@ __version__ = "0.5.0"
 
 __all__ = [
     "error_info", "init", "connect", "disconnect", "get", "put", "wait",
-    "remote", "profile", "flush_profile_data", "actor", "method",
+    "remote", "profile", "actor", "method",
     "get_gpu_ids", "get_resource_ids", "get_webui_url",
     "register_custom_serializer", "shutdown", "SCRIPT_MODE", "WORKER_MODE",
     "LOCAL_MODE", "SILENT_MODE", "global_state", "ObjectID", "_config",

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -78,20 +78,20 @@ class ImportThread(object):
         # Handle the driver case first.
         if self.mode != ray.WORKER_MODE:
             if key.startswith(b"FunctionsToRun"):
-                with profiling.profile("fetch_and_run_function",
-                                       worker=self.worker):
+                with profiling.profile(
+                        "fetch_and_run_function", worker=self.worker):
                     self.fetch_and_execute_function_to_run(key)
             # Return because FunctionsToRun are the only things that
             # the driver should import.
             return
 
         if key.startswith(b"RemoteFunction"):
-            with profiling.profile("register_remote_function",
-                                   worker=self.worker):
+            with profiling.profile(
+                    "register_remote_function", worker=self.worker):
                 self.fetch_and_register_remote_function(key)
         elif key.startswith(b"FunctionsToRun"):
-            with profiling.profile("fetch_and_run_function",
-                                   worker=self.worker):
+            with profiling.profile(
+                    "fetch_and_run_function", worker=self.worker):
                 self.fetch_and_execute_function_to_run(key)
         elif key.startswith(b"ActorClass"):
             # Keep track of the fact that this actor class has been

--- a/python/ray/import_thread.py
+++ b/python/ray/import_thread.py
@@ -10,6 +10,7 @@ import redis
 import ray
 from ray import ray_constants
 from ray import cloudpickle as pickle
+from ray import profiling
 from ray import utils
 
 
@@ -74,21 +75,23 @@ class ImportThread(object):
 
     def _process_key(self, key):
         """Process the given export key from redis."""
-        from ray.worker import profile, WORKER_MODE
         # Handle the driver case first.
-        if self.mode != WORKER_MODE:
+        if self.mode != ray.WORKER_MODE:
             if key.startswith(b"FunctionsToRun"):
-                with profile("fetch_and_run_function", worker=self.worker):
+                with profiling.profile("fetch_and_run_function",
+                                       worker=self.worker):
                     self.fetch_and_execute_function_to_run(key)
             # Return because FunctionsToRun are the only things that
             # the driver should import.
             return
 
         if key.startswith(b"RemoteFunction"):
-            with profile("register_remote_function", worker=self.worker):
+            with profiling.profile("register_remote_function",
+                                   worker=self.worker):
                 self.fetch_and_register_remote_function(key)
         elif key.startswith(b"FunctionsToRun"):
-            with profile("fetch_and_run_function", worker=self.worker):
+            with profiling.profile("fetch_and_run_function",
+                                   worker=self.worker):
                 self.fetch_and_execute_function_to_run(key)
         elif key.startswith(b"ActorClass"):
             # Keep track of the fact that this actor class has been
@@ -154,11 +157,10 @@ class ImportThread(object):
 
     def fetch_and_execute_function_to_run(self, key):
         """Run on arbitrary function on the worker."""
-        from ray.worker import SCRIPT_MODE, SILENT_MODE
         driver_id, serialized_function = self.redis_client.hmget(
             key, ["driver_id", "function"])
 
-        if (self.worker.mode in [SCRIPT_MODE, SILENT_MODE]
+        if (self.worker.mode in [ray.SCRIPT_MODE, ray.SILENT_MODE]
                 and driver_id != self.worker.task_driver_id.id()):
             # This export was from a different driver and there's no need for
             # this driver to import it.

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -1,0 +1,270 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import json
+import time
+import threading
+import traceback
+
+import ray
+
+LOG_POINT = 0
+LOG_SPAN_START = 1
+LOG_SPAN_END = 2
+
+
+class _NullLogSpan(object):
+    """A log span context manager that does nothing"""
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self):
+        pass
+
+
+NULL_LOG_SPAN = _NullLogSpan()
+
+
+def profile(event_type, extra_data=None, worker=None):
+    """Profile a span of time so that it appears in the timeline visualization.
+
+    Note that this only works in the raylet code path.
+
+    This function can be used as follows (both on the driver or within a task).
+
+    .. code-block:: python
+
+        with ray.profile("custom event", extra_data={'key': 'value'}):
+            # Do some computation here.
+
+    Optionally, a dictionary can be passed as the "extra_data" argument, and
+    it can have keys "name" and "cname" if you want to override the default
+    timeline display text and box color. Other values will appear at the bottom
+    of the chrome tracing GUI when you click on the box corresponding to this
+    profile span.
+
+    Args:
+        event_type: A string describing the type of the event.
+        extra_data: This must be a dictionary mapping strings to strings. This
+            data will be added to the json objects that are used to populate
+            the timeline, so if you want to set a particular color, you can
+            simply set the "cname" attribute to an appropriate color.
+            Similarly, if you set the "name" attribute, then that will set the
+            text displayed on the box in the timeline.
+
+    Returns:
+        An object that can profile a span of time via a "with" statement.
+    """
+    if worker is None:
+        worker = ray.worker.global_worker
+    if not worker.use_raylet:
+        # Log the event if this is a worker and not a driver, since the
+        # driver's event log never gets flushed.
+        if worker.mode == ray.WORKER_MODE:
+            return RayLogSpan(worker.profiler, event_type, contents=extra_data)
+        else:
+            return NULL_LOG_SPAN
+    else:
+        return RayLogSpanRaylet(
+            worker.profiler, event_type, extra_data=extra_data)
+
+
+class Profiler(object):
+    """A class that holds the profiling states.
+
+    Attributes:
+        worker: the worker to profile.
+        events: the buffer of events.
+        lock: the lock to protect access of events.
+    """
+
+    def __init__(self, worker):
+        self.worker = worker
+        self.events = []
+        self.lock = threading.Lock()
+
+    def start_flush_thread(self):
+        t = threading.Thread(target=self._periodically_flush_profile_events)
+        # Making the thread a daemon causes it to exit when the main thread
+        # exits.
+        t.daemon = True
+        t.start()
+
+    def _periodically_flush_profile_events(self):
+        """Drivers run this as a thread to flush profile data in the
+        background."""
+        # Note(rkn): This is run on a background thread in the driver. It uses
+        # the local scheduler client. This should be ok because it doesn't read
+        # from the local scheduler client and we have the GIL here. However,
+        # if either of those things changes, then we could run into issues.
+        try:
+            while True:
+                time.sleep(1)
+                self.flush_profile_data()
+        except AttributeError:
+            # This is to suppress errors that occur at shutdown.
+            pass
+
+    # TODO(rkn): Support calling this function in the middle of a task, and
+    # also call this periodically in the background from the driver.
+    def flush_profile_data(self):
+        """Push the logged profiling data to the global control store.
+
+        By default, profiling information for a given task won't appear in the
+        timeline until after the task has completed. For very long-running
+        tasks, we may want profiling information to appear more quickly.
+        In such cases, this function can be called. Note that as an
+        aalternative, we could start thread in the background on workers that
+        calls this automatically.
+        """
+        with self.lock:
+            events = self.events
+            self.events = []
+
+        if not self.worker.use_raylet:
+            event_log_key = b"event_log:" + self.worker.worker_id
+            event_log_value = json.dumps(events)
+            self.worker.local_scheduler_client.log_event(
+                event_log_key, event_log_value, time.time())
+        else:
+            if self.worker.mode == ray.WORKER_MODE:
+                component_type = "worker"
+            else:
+                component_type = "driver"
+
+            self.worker.local_scheduler_client.push_profile_events(
+                component_type, ray.ObjectID(self.worker.worker_id),
+                self.worker.node_ip_address, events)
+
+    def add_event(self, event):
+        with self.lock:
+            self.events.append(event)
+
+
+class RayLogSpan(object):
+    """An object used to enable logging a span of events with a with statement.
+
+    Attributes:
+        event_type (str): The type of the event being logged.
+        contents: Additional information to log.
+    """
+
+    def __init__(self, profiler, event_type, contents=None):
+        """Initialize a RayLogSpan object."""
+        self.profiler = profiler
+        self.event_type = event_type
+        self.contents = contents
+
+    def _log(self, event_type, kind, contents=None):
+        """Log an event to the global state store.
+
+        This adds the event to a buffer of events locally. The buffer can be
+        flushed and written to the global state store by calling
+        flush_profile_data().
+
+        Args:
+            event_type (str): The type of the event.
+            contents: More general data to store with the event.
+            kind (int): Either LOG_POINT, LOG_SPAN_START, or LOG_SPAN_END. This
+                is LOG_POINT if the event being logged happens at a single
+                point in time. It is LOG_SPAN_START if we are starting to log a
+                span of time, and it is LOG_SPAN_END if we are finishing
+                logging a span of time.
+        """
+        # TODO(rkn): This code currently takes around half a microsecond. Since
+        # we call it tens of times per task, this adds up. We will need to redo
+        # the logging code, perhaps in C.
+        contents = {} if contents is None else contents
+        assert isinstance(contents, dict)
+        # Make sure all of the keys and values in the dictionary are strings.
+        contents = {str(k): str(v) for k, v in contents.items()}
+        self.profiler.add_event((time.time(), event_type, kind, contents))
+
+    def __enter__(self):
+        """Log the beginning of a span event."""
+        self._log(
+            event_type=self.event_type,
+            contents=self.contents,
+            kind=LOG_SPAN_START)
+
+    def __exit__(self, type, value, tb):
+        """Log the end of a span event. Log any exception that occurred."""
+        if type is None:
+            self._log(event_type=self.event_type, kind=LOG_SPAN_END)
+        else:
+            self._log(
+                event_type=self.event_type,
+                contents={
+                    "type": str(type),
+                    "value": value,
+                    "traceback": traceback.format_exc()
+                },
+                kind=LOG_SPAN_END)
+
+
+class RayLogSpanRaylet(object):
+    """An object used to enable logging a span of events with a with statement.
+
+    Attributes:
+        event_type (str): The type of the event being logged.
+        contents: Additional information to log.
+    """
+
+    def __init__(self, profiler, event_type, extra_data=None):
+        """Initialize a RayLogSpan object."""
+        self.profiler = profiler
+        self.event_type = event_type
+        self.extra_data = extra_data if extra_data is not None else {}
+
+    def set_attribute(self, key, value):
+        """Add a key-value pair to the extra_data dict.
+
+        This can be used to add attributes that are not available when
+        ray.profile was called.
+
+        Args:
+            key: The attribute name.
+            value: The attribute value.
+        """
+        if not isinstance(key, str) or not isinstance(value, str):
+            raise ValueError("The extra_data argument must be a "
+                             "dictionary mapping strings to strings.")
+        self.extra_data[key] = value
+
+    def __enter__(self):
+        """Log the beginning of a span event.
+
+        Returns:
+            The object itself is returned so that if the block is opened using
+                "with ray.profile(...) as prof:", we can call
+                "prof.set_attribute" inside the block.
+        """
+        self.start_time = time.time()
+        return self
+
+    def __exit__(self, type, value, tb):
+        """Log the end of a span event. Log any exception that occurred."""
+        for key, value in self.extra_data.items():
+            if not isinstance(key, str) or not isinstance(value, str):
+                raise ValueError("The extra_data argument must be a "
+                                 "dictionary mapping strings to strings.")
+
+        if type is not None:
+            extra_data = json.dumps({
+                "type": str(type),
+                "value": str(value),
+                "traceback": str(traceback.format_exc()),
+            })
+        else:
+            extra_data = json.dumps(self.extra_data)
+
+        event = {
+            "event_type": self.event_type,
+            "start_time": self.start_time,
+            "end_time": time.time(),
+            "extra_data": extra_data,
+        }
+
+        self.profiler.add_event(event)

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -63,7 +63,8 @@ def profile(event_type, extra_data=None, worker=None):
         # Log the event if this is a worker and not a driver, since the
         # driver's event log never gets flushed.
         if worker.mode == ray.WORKER_MODE:
-            return RayLogSpanNonRaylet(worker.profiler, event_type, contents=extra_data)
+            return RayLogSpanNonRaylet(
+                worker.profiler, event_type, contents=extra_data)
         else:
             return NULL_LOG_SPAN
     else:

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -20,7 +20,7 @@ class _NullLogSpan(object):
     def __enter__(self):
         pass
 
-    def __exit__(self):
+    def __exit__(self, type, value, tb):
         pass
 
 

--- a/python/ray/profiling.py
+++ b/python/ray/profiling.py
@@ -63,7 +63,7 @@ def profile(event_type, extra_data=None, worker=None):
         # Log the event if this is a worker and not a driver, since the
         # driver's event log never gets flushed.
         if worker.mode == ray.WORKER_MODE:
-            return RayLogSpan(worker.profiler, event_type, contents=extra_data)
+            return RayLogSpanNonRaylet(worker.profiler, event_type, contents=extra_data)
         else:
             return NULL_LOG_SPAN
     else:
@@ -143,7 +143,7 @@ class Profiler(object):
             self.events.append(event)
 
 
-class RayLogSpan(object):
+class RayLogSpanNonRaylet(object):
     """An object used to enable logging a span of events with a with statement.
 
     Attributes:
@@ -152,7 +152,7 @@ class RayLogSpan(object):
     """
 
     def __init__(self, profiler, event_type, contents=None):
-        """Initialize a RayLogSpan object."""
+        """Initialize a RayLogSpanNonRaylet object."""
         self.profiler = profiler
         self.event_type = event_type
         self.contents = contents
@@ -213,7 +213,7 @@ class RayLogSpanRaylet(object):
     """
 
     def __init__(self, profiler, event_type, extra_data=None):
-        """Initialize a RayLogSpan object."""
+        """Initialize a RayLogSpanRaylet object."""
         self.profiler = profiler
         self.event_type = event_type
         self.extra_data = extra_data if extra_data is not None else {}

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -2006,11 +2006,6 @@ def connect(info,
     worker.set_mode(mode)
     worker.use_raylet = use_raylet
 
-    # The worker.events field is used to aggregate logging information and
-    # display it in the web UI. Note that Python lists protected by the GIL,
-    # which is important because we will append to this field from multiple
-    # threads.
-    worker.events = []
     # If running Ray in LOCAL_MODE, there is no need to create call
     # create_worker or to start the worker service.
     if mode == LOCAL_MODE:

--- a/python/ray/worker.py
+++ b/python/ray/worker.py
@@ -199,6 +199,7 @@ class Worker(object):
             that connect has been called already.
         cached_functions_to_run (List): A list of functions to run on all of
             the workers that should be exported as soon as connect is called.
+        profiler: the profiler used to aggregate profiling information.
     """
 
     def __init__(self):


### PR DESCRIPTION
## What do these changes do?

- Move profiling code to a new file `python/ray.profiling.py`.
- Use a `Profiler` class to hold profiling events buffer, which was previously held in the worker (`worker.events` -> `worker.profiler.events`).
- Protect the events buffer with a lock (because it's being accessed from 2 threads).
- Minor efficiency improvement: for non-raylet code path, events will be logged only if worker mode is worker. Thus we don't need to create new LogSpan when worker mode isn't worker (see the old `_log` function and the new `profile` function).