### PR TITLE
java worker tutorial

### DIFF
--- a/java/example/src/main/java/org/ray/exercise/Exercise01.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise01.java
@@ -1,0 +1,50 @@
+package org.ray.exercise;
+
+import java.io.Serializable;
+import org.ray.api.Ray;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.core.RayRuntime;
+
+/**
+ * Define a remote function, and execute multiple remote functions in parallel.
+ */
+public class Exercise01 implements Serializable {
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String sayHello() {
+    String ret = "hello";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String sayWorld() {
+    String ret = "world!";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) throws Exception {
+    try {
+      Ray.init();
+      RayObject<String> hello = Ray.call(Exercise01::sayHello);
+      RayObject<String> world = Ray.call(Exercise01::sayWorld);
+      System.out.println("first remote call result:" + hello.get());
+      System.out.println("second remote call result:" + world.get());
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise02.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise02.java
@@ -1,0 +1,66 @@
+package org.ray.exercise;
+
+import org.ray.api.Ray;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.core.RayRuntime;
+import org.ray.example.HelloWorld;
+
+/**
+ * Execute remote functions in parallel with some dependencies.
+ */
+public class Exercise02 {
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String sayHello() {
+    String ret = "hello";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String sayWorld() {
+    String ret = "world!";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Remote function with dependency.
+   */
+  @RayRemote
+  public static String merge(String hello, String world) {
+    return hello + "," + world;
+  }
+
+  /**
+   * Entry function.
+   */
+  public static String sayHelloWorld() {
+    RayObject<String> hello = Ray.call(HelloWorld::sayHello);
+    RayObject<String> world = Ray.call(HelloWorld::sayWorld);
+    return Ray.call(HelloWorld::merge, hello, world).get();
+  }
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) throws Exception {
+    try {
+      Ray.init();
+      String helloWorld = HelloWorld.sayHelloWorld();
+      System.out.println(helloWorld);
+      assert helloWorld.equals("hello,world!");
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise03.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise03.java
@@ -1,0 +1,48 @@
+package org.ray.exercise;
+
+import org.ray.api.Ray;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.core.RayRuntime;
+
+/**
+ * Call remote functions from within remote functions.
+ */
+public class Exercise03 {
+
+  /**
+   * Remote function which will call another remote function.
+   */
+  @RayRemote
+  public static String sayHelloWithWorld() {
+    String ret = "hello";
+    System.out.println(ret);
+    RayObject<String> world = Ray.call(Exercise03::sayWorld);
+    return ret + "," + world.get();
+  }
+
+  /**
+   * Remote function which will be called by another remote function.
+   */
+  @RayRemote
+  public static String sayWorld() {
+    String ret = "world!";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) throws Exception {
+    try {
+      Ray.init();
+      String helloWithWorld = Ray.call(Exercise03::sayHelloWithWorld).get();
+      System.out.println(helloWithWorld);
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise04.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise04.java
@@ -1,0 +1,80 @@
+package org.ray.exercise;
+
+import org.ray.api.Ray;
+import org.ray.api.RayList;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.api.WaitResult;
+import org.ray.core.RayRuntime;
+
+/**
+ * Use Ray.wait to ignore stragglers
+ */
+public class Exercise04 {
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String f1() {
+    String ret = "f1";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String f2() {
+    String ret = "f2";
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static String f3() {
+    String ret = "f3";
+    try {
+      Thread.sleep(5000L);
+    } catch (Exception e) {
+      e.printStackTrace();
+    }
+    System.out.println(ret);
+    return ret;
+  }
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) throws Exception {
+    try {
+      Ray.init();
+      RayObject<String> o1 = Ray.call(Exercise04::f1);
+      RayObject<String> o2 = Ray.call(Exercise04::f2);
+      RayObject<String> o3 = Ray.call(Exercise04::f3);
+      RayList<String> rayList = new RayList<>();
+      rayList.add(o1);
+      rayList.add(o2);
+      rayList.add(o3);
+      WaitResult<String> waitResult = Ray.wait(rayList,2, 3000);
+      RayList<String> readyOnes = waitResult.getReadyOnes();
+      RayList<String> remainOnes = waitResult.getRemainOnes();
+      System.out.println("Number of readyOnes: " + readyOnes.size());
+      for (int i = 0; i < readyOnes.size(); i++) {
+        System.out.println("The value of readyOnes " + i + " is " + readyOnes.get(i));
+      }
+      System.out.println("Number of remainOnes: " + remainOnes.size());
+      for (int i = 0; i < remainOnes.size(); i++) {
+        System.out.println("The value of remainOnes " + i + " is " + remainOnes.get(i));
+      }
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise05.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise05.java
@@ -1,0 +1,42 @@
+package org.ray.exercise;
+
+import org.ray.api.Ray;
+import org.ray.api.RayRemote;
+import org.ray.api.returns.MultipleReturns2;
+import org.ray.api.returns.RayObjects2;
+import org.ray.core.RayRuntime;
+
+/**
+ * Enable multiple heterogeneous return values
+ * Java worker support at most four multiple heterogeneous return values,
+ * and in order to let the runtime know the number of return values we
+ * supply the method of ``Ray.call_X`` as follows.
+ */
+public class Exercise05 {
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) {
+    try {
+      Ray.init();
+      RayObjects2<Integer, String> refs = Ray.call_2(Exercise05::sayMultiRet);
+      Integer obj1 = refs.r0().get();
+      String obj2 = refs.r1().get();
+      System.out.println(obj1);
+      System.out.println(obj2);
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+
+  /**
+   * Remote function with MultipleReturns.
+   */
+  @RayRemote
+  public static MultipleReturns2<Integer, String> sayMultiRet() {
+    return new MultipleReturns2<Integer, String>(123, "123");
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise06.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise06.java
@@ -1,0 +1,48 @@
+package org.ray.exercise;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.ray.api.Ray;
+import org.ray.api.RayList;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.core.RayRuntime;
+
+/**
+ * Usage of RayList.
+ * A list of ``RayObject``, inherited from ``List`` in Java. It can
+ * be used as the type for both return value and parameters.
+ *
+ */
+public class Exercise06 {
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) {
+    try {
+      Ray.init();
+      RayList<Integer> ns = Ray.call_n(Exercise06::sayList, 10, 10);
+      for (int i = 0; i < 10; i++) {
+        RayObject<Integer> obj = ns.Get(i);
+        System.out.println(obj.get());
+      }
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static List<Integer> sayList(Integer count) {
+    ArrayList<Integer> rets = new ArrayList<>();
+    for (int i = 0; i < count; i++) {
+      rets.add(i);
+    }
+    return rets;
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise07.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise07.java
@@ -1,0 +1,51 @@
+package org.ray.exercise;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import org.ray.api.Ray;
+import org.ray.api.RayMap;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.core.RayRuntime;
+
+/**
+ * Usage of RayMap
+ * A map of ``RayObject``
+ * inherited from ``Map``. It can be used as the type for both
+ * return value and parameters.
+ */
+public class Exercise07 {
+  /**
+   * Main.
+   */
+  public static void main(String[] args) {
+    try {
+      Ray.init();
+      RayMap<Integer, String> ns = Ray.call_n(Exercise07::sayMap,
+          Arrays.asList(1, 2, 4, 3), "n_futures_");
+      for (Map.Entry<Integer, RayObject<String>> ne : ns.EntrySet()) {
+        Integer key = ne.getKey();
+        RayObject<String> obj = ne.getValue();
+        System.out.println(obj.get());
+      }
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote()
+  public static Map<Integer, String> sayMap(Collection<Integer> ids, String prefix) {
+    Map<Integer, String> ret = new HashMap<>();
+    for (int id : ids) {
+      ret.put(id, prefix + id);
+    }
+    return ret;
+  }
+}

--- a/java/example/src/main/java/org/ray/exercise/Exercise08.java
+++ b/java/example/src/main/java/org/ray/exercise/Exercise08.java
@@ -1,0 +1,47 @@
+package org.ray.exercise;
+
+import org.ray.api.Ray;
+import org.ray.api.RayActor;
+import org.ray.api.RayObject;
+import org.ray.api.RayRemote;
+import org.ray.core.RayRuntime;
+
+/**
+ * Actor Support of create Actor and call Actor method.
+ */
+public class Exercise08 {
+
+  /**
+   * Main.
+   */
+  public static void main(String[] args) {
+    try {
+      Ray.init();
+      RayActor<Adder> adder = Ray.create(Adder.class);
+      RayObject<Integer> result1 = Ray.call(Adder::add, adder, 1);
+      RayObject<Integer> result2 = Ray.call(Adder::add, adder, 10);
+      System.out.println(result1.get());
+      System.out.println(result2.get());
+    } catch (Throwable t) {
+      t.printStackTrace();
+    } finally {
+      RayRuntime.getInstance().cleanUp();
+    }
+  }
+
+  /**
+   * Remote function.
+   */
+  @RayRemote
+  public static class Adder {
+    public Adder() {
+      sum = 0;
+    }
+
+    public Integer add(Integer n) {
+      return sum += n;
+    }
+
+    private Integer sum;
+  }
+}

--- a/java/tutorial.rst
+++ b/java/tutorial.rst
@@ -1,0 +1,59 @@
+Ray Java Tutorial
+============
+
+Requirement
+-----
+::
+
+    JDK (>=8.0)
+
+    Maven(>=3.5.0)
+
+Setup
+-----
+::
+
+    # build native components
+    ../build.sh -l java
+
+    # build java worker
+    mvn clean install -Dmaven.test.skip
+
+    # set config file and test
+    # The RAY_CONFIG please set the absolute path of the ray.config.ini in your disk
+    export RAY_CONFIG=/rootpath/ray/java/ray.config.ini
+    mvn test
+
+Introduction of Api
+---------
+Please reference the java `README.rst`_
+
+Exercises
+---------
+
+Each file ``java/example/src/main/java/org/ray/exercise/Exercise*.java`` is a separate exercise.
+Before we run the exercise case, we have to run the command of setup step especially set RAY_CONFIG,
+and entry to the java root package. And we could run the Exercise01 with the command below.
+
+.. code-block:: shell
+
+    java -Djava.library.path=../build/src/plasma/:../build/src/local_scheduler/ -classpath "example/target/ray-example-1.0.jar:test/lib/*" org.ray.exercise.Exercise01
+
+**Exercise 1:** Define a remote function, and execute multiple remote functions in parallel.
+
+**Exercise 2:** Execute remote functions in parallel with some dependencies.
+
+**Exercise 3:** Call remote functions from within remote functions.
+
+**Exercise 4:** Use ``Ray.wait`` to ignore stragglers.
+
+**Exercise 5:** Enable multiple heterogeneous return values.
+
+**Exercise 6:** Usage of ``RayList<T>``.
+
+**Exercise 7:** Usage of ``RayMap<L, T>``.
+
+**Exercise 8:** Actor Support of create Actor and call Actor method.
+
+.. _`README.rst`: https://github.com/ray-project/ray/tree/master/java
+


### PR DESCRIPTION
Add java worker tutorial
As we already have README.rst for the description of java worker module, build and test, quick start, description of api and sample code for these api, and have example module for sample code, we just reference the tutorial of python https://github.com/ray-project/tutorial,  add exercise code and description, and ensure users could run the exercise with least command in the tutorial.rst.
And this tutorial is generated with the help of @imzhenyu and @raulchen .