### PR TITLE
Change the command line arguments to start raylet.

### DIFF
--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -2,6 +2,7 @@ package org.ray.runner;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.Array;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -198,11 +199,12 @@ public class RunManager {
     }
 
     int processIndex = runInfo.allProcesses.get(type.ordinal()).size();
+
     ProcessBuilder builder;
-    List<String> newCmd = Arrays.stream(cmd).filter(s -> s.length() > 0)
-        .collect(Collectors.toList());
-    builder = new ProcessBuilder(newCmd);
+    List<String> newCommand = Arrays.asList(cmd);
+    builder = new ProcessBuilder(newCommand);
     builder.directory(new File(workDir));
+
     if (redirect) {
       String stdoutFile;
       String stderrFile;
@@ -690,9 +692,10 @@ public class RunManager {
 
     String filePath = paths.raylet;
     
-    String workerCmd = null;
-    workerCmd = buildWorkerCommandRaylet(info.storeName, rayletSocketName, UniqueID.nil,
-            "", workDir + rpcPort, ip, redisAddress);
+    String javaWorkerCommand = null;
+    String pythonWorkerCommand = "";
+    javaWorkerCommand = buildWorkerCommandRaylet(info.storeName, rayletSocketName, UniqueID.nil,
+        "", workDir + rpcPort, ip, redisAddress);
 
     int sep = redisAddress.indexOf(':');
     assert (sep != -1);
@@ -701,8 +704,9 @@ public class RunManager {
 
     String resourceArgument = ResourceUtil.getResourcesStringFromMap(staticResources);
 
-    String[] cmds = new String[]{filePath, rayletSocketName, storeName, ip, gcsIp,
-                                 gcsPort, "" + numWorkers, workerCmd, resourceArgument};
+    String[] cmds = new String[] {filePath, rayletSocketName, storeName, ip, gcsIp,
+                                  gcsPort, "" + numWorkers, resourceArgument,
+                                  javaWorkerCommand, pythonWorkerCommand};
 
     Process p = startProcess(cmds, null, RunInfo.ProcessType.PT_RAYLET,
         workDir + rpcPort, redisAddress, ip, redirect, cleanup);

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -973,14 +973,17 @@ def start_raylet(redis_address,
     gcs_ip_address, gcs_port = redis_address.split(":")
     raylet_name = "/tmp/raylet{}".format(random_name())
 
-    # Create the command that the Raylet will use to start workers.
-    start_worker_command = ("{} {} "
-                            "--node-ip-address={} "
-                            "--object-store-name={} "
-                            "--raylet-name={} "
-                            "--redis-address={}".format(
-                                sys.executable, worker_path, node_ip_address,
-                                plasma_store_name, raylet_name, redis_address))
+    # Create the python command that the Raylet will use to start workers.
+    start_python_worker_command = ("{} {} "
+                                   "--node-ip-address={} "
+                                   "--object-store-name={} "
+                                    "--raylet-name={} "
+                                    "--redis-address={}".format(
+                                    sys.executable, worker_path, node_ip_address,
+                                    plasma_store_name, raylet_name, redis_address))
+
+    # Create an empty java command. This is just a placeholder.
+    start_java_worker_command = ""
 
     command = [
         RAYLET_EXECUTABLE,
@@ -990,8 +993,9 @@ def start_raylet(redis_address,
         gcs_ip_address,
         gcs_port,
         str(num_workers),
-        start_worker_command,
         resource_argument,
+        start_java_worker_command,
+        start_python_worker_command
     ]
 
     if use_valgrind:

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -6,7 +6,7 @@
 
 #ifndef RAYLET_TEST
 int main(int argc, char *argv[]) {
-  RAY_CHECK(argc == 9);
+  RAY_CHECK(argc == 10);
 
   const std::string raylet_socket_name = std::string(argv[1]);
   const std::string store_socket_name = std::string(argv[2]);
@@ -14,8 +14,12 @@ int main(int argc, char *argv[]) {
   const std::string redis_address = std::string(argv[4]);
   int redis_port = std::stoi(argv[5]);
   int num_initial_workers = std::stoi(argv[6]);
-  const std::string worker_command = std::string(argv[7]);
-  const std::string static_resource_list = std::string(argv[8]);
+  const std::string static_resource_list = std::string(argv[7]);
+
+  // If you want to pass one worker command,
+  // the other one should be passed by a empty string.
+  const std::string java_worker_command = std::string(argv[8]);
+  const std::string python_worker_command = std::string(argv[9]);
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;
@@ -39,10 +43,25 @@ int main(int argc, char *argv[]) {
       RayConfig::instance().num_workers_per_process();
   // Use a default worker that can execute empty tasks with dependencies.
 
-  std::istringstream iss(worker_command);
-  std::vector<std::string> results(std::istream_iterator<std::string>{iss},
-                                   std::istream_iterator<std::string>());
-  node_manager_config.worker_command.swap(results);
+  // TODO(qingw): Extract this 2 pieces of code to a common helper function.
+  {
+    if (!java_worker_command.empty()) {
+      std::istringstream iss(java_worker_command);
+      std::vector<std::string> results(std::istream_iterator<std::string>{iss},
+                                       std::istream_iterator<std::string>());
+      node_manager_config.java_worker_command.swap(results);
+    }
+  }
+
+  {
+    if (!python_worker_command.empty()) {
+      std::istringstream iss(python_worker_command);
+      std::vector<std::string> results(std::istream_iterator<std::string>{iss},
+                                       std::istream_iterator<std::string>());
+      node_manager_config.python_worker_command.swap(results);
+    }
+  }
+
 
   node_manager_config.heartbeat_period_ms =
       RayConfig::instance().heartbeat_timeout_milliseconds();

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -87,7 +87,7 @@ NodeManager::NodeManager(boost::asio::io_service &io_service,
       local_available_resources_(config.resource_config),
       worker_pool_(config.num_initial_workers, config.num_workers_per_process,
                    static_cast<int>(config.resource_config.GetNumCpus()),
-                   config.worker_command),
+                   config.java_worker_command, config.python_worker_command),
       local_queues_(SchedulingQueue()),
       scheduling_policy_(local_queues_),
       reconstruction_policy_(

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -25,7 +25,8 @@ struct NodeManagerConfig {
   ResourceSet resource_config;
   int num_initial_workers;
   int num_workers_per_process;
-  std::vector<std::string> worker_command;
+  std::vector<std::string> java_worker_command;
+  std::vector<std::string> python_worker_command;
   uint64_t heartbeat_period_ms;
   uint64_t max_lineage_size;
   /// The store socket name.

--- a/src/ray/raylet/object_manager_integration_test.cc
+++ b/src/ray/raylet/object_manager_integration_test.cc
@@ -39,11 +39,11 @@ class TestObjectManagerBase : public ::testing::Test {
     node_manager_config.num_initial_workers = 0;
     node_manager_config.num_workers_per_process = 1;
     // Use a default worker that can execute empty tasks with dependencies.
-    node_manager_config.worker_command.push_back("python");
-    node_manager_config.worker_command.push_back(
+    node_manager_config.python_worker_command.push_back("python");
+    node_manager_config.python_worker_command.push_back(
         "../python/ray/workers/default_worker.py");
-    node_manager_config.worker_command.push_back(raylet_socket_name.c_str());
-    node_manager_config.worker_command.push_back(store_socket_name.c_str());
+    node_manager_config.python_worker_command.push_back(raylet_socket_name.c_str());
+    node_manager_config.python_worker_command.push_back(store_socket_name.c_str());
     return node_manager_config;
   };
 

--- a/src/ray/raylet/worker_pool.h
+++ b/src/ray/raylet/worker_pool.h
@@ -30,17 +30,14 @@ class WorkerPool {
   /// \param num_workers_per_process The number of workers per process.
   /// \param worker_command The command used to start the worker process.
   WorkerPool(int num_worker_processes, int num_workers_per_process, int num_cpus,
-             const std::vector<std::string> &worker_command);
+             const std::vector<std::string> &java_worker_command,
+             const std::vector<std::string> &python_worker_command);
 
   /// Destructor responsible for freeing a set of workers owned by this class.
   virtual ~WorkerPool();
 
-  /// Asynchronously start a new worker process. Once the worker process has
-  /// registered with an external server, the process should create and
-  /// register num_workers_per_process_ workers, then add them to the pool.
-  /// Failure to start the worker process is a fatal error.
-  /// This function will start up to num_cpus many workers in parallel
-  /// if it is called multiple times.
+  /// Asynchronously start a new worker process.
+  /// This is the wrapper function for `StartWorkerProcessWithCommand`.
   ///
   /// \param force_start Controls whether to force starting a worker regardless of any
   /// workers that have already been started but not yet registered.
@@ -111,10 +108,27 @@ class WorkerPool {
   int num_workers_per_process_;
 
  private:
+  /// Asynchronously start a new worker process. Once the worker process has
+  /// registered with an external server, the process should create and
+  /// register num_workers_per_process_ workers, then add them to the pool.
+  /// Failure to start the worker process is a fatal error.
+  /// This function will start up to num_cpus many workers in parallel
+  /// if it is called multiple times.
+  ///
+  /// \param worker_command The command that we start a worker process.
+  /// \param force_start Controls whether to force starting a worker regardless of any
+  /// workers that have already been started but not yet registered.
+  void StartWorkerProcessWithCommand(const std::vector<std::string> &worker_command,
+                                     bool force_start);
+
+private:
   /// The number of CPUs this Raylet has available.
   int num_cpus_;
-  /// The command and arguments used to start the worker.
-  std::vector<std::string> worker_command_;
+  /// The command and arguments used to start the java worker.
+  std::vector<std::string> java_worker_command_;
+  /// The command and arguments used to start the python worker.
+  std::vector<std::string> python_worker_command_;
+
   /// The pool of idle workers.
   std::list<std::shared_ptr<Worker>> pool_;
   /// The pool of idle actor workers.

--- a/src/ray/raylet/worker_pool_test.cc
+++ b/src/ray/raylet/worker_pool_test.cc
@@ -12,7 +12,7 @@ int NUM_WORKERS_PER_PROCESS = 3;
 
 class WorkerPoolMock : public WorkerPool {
  public:
-  WorkerPoolMock() : WorkerPool(0, NUM_WORKERS_PER_PROCESS, 0, {}) {}
+  WorkerPoolMock() : WorkerPool(0, NUM_WORKERS_PER_PROCESS, 0, {}, {}) {}
 
   void StartWorkerProcess(pid_t pid, bool force_start = false) {
     if (starting_worker_processes_.size() > 0 && !force_start) {


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
For supporting multi-language, `raylet` should receive different command line arguments to start itself. 

In java, we should start `raylet` by the command as blew:
```
raylet raylet_socket_name store_socket_name node_ip_address redis_address redis_port num_initial_workers static_resource_list java_worker_command ""
```

Note:The last argument is `python_worker_command`. In java, it must be empty string right now.

Similarly, we should start `raylet` in python by this command:
```
raylet raylet_socket_name store_socket_name node_ip_address redis_address redis_port num_initial_workers static_resource_list  "" python_worker_command
```

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
