### PR TITLE
Change the command line arguments to start raylet.

### DIFF
--- a/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
+++ b/java/runtime-native/src/main/java/org/ray/runner/RunManager.java
@@ -198,11 +198,12 @@ public class RunManager {
     }
 
     int processIndex = runInfo.allProcesses.get(type.ordinal()).size();
+
     ProcessBuilder builder;
-    List<String> newCmd = Arrays.stream(cmd).filter(s -> s.length() > 0)
-        .collect(Collectors.toList());
-    builder = new ProcessBuilder(newCmd);
+    List<String> newCommand = Arrays.asList(cmd);
+    builder = new ProcessBuilder(newCommand);
     builder.directory(new File(workDir));
+
     if (redirect) {
       String stdoutFile;
       String stderrFile;
@@ -689,10 +690,12 @@ public class RunManager {
     String rayletSocketName = "/tmp/raylet" + rpcPort;
 
     String filePath = paths.raylet;
-    
-    String workerCmd = null;
-    workerCmd = buildWorkerCommandRaylet(info.storeName, rayletSocketName, UniqueID.nil,
-            "", workDir + rpcPort, ip, redisAddress);
+
+    //Create the java worker command that the raylet will use to start workers.
+    String javaWorkerCommand  = buildWorkerCommandRaylet(info.storeName, rayletSocketName,
+        UniqueID.nil, "", workDir + rpcPort, ip, redisAddress);
+    // Create the python worker command, This is just a placeholder.
+    String pythonWorkerCommand = "";
 
     int sep = redisAddress.indexOf(':');
     assert (sep != -1);
@@ -702,7 +705,8 @@ public class RunManager {
     String resourceArgument = ResourceUtil.getResourcesStringFromMap(staticResources);
 
     String[] cmds = new String[]{filePath, rayletSocketName, storeName, ip, gcsIp,
-                                 gcsPort, "" + numWorkers, workerCmd, resourceArgument};
+                                 gcsPort, "" + numWorkers, resourceArgument,
+                                 javaWorkerCommand, pythonWorkerCommand};
 
     Process p = startProcess(cmds, null, RunInfo.ProcessType.PT_RAYLET,
         workDir + rpcPort, redisAddress, ip, redirect, cleanup);

--- a/python/ray/services.py
+++ b/python/ray/services.py
@@ -973,14 +973,17 @@ def start_raylet(redis_address,
     gcs_ip_address, gcs_port = redis_address.split(":")
     raylet_name = "/tmp/raylet{}".format(random_name())
 
-    # Create the command that the Raylet will use to start workers.
-    start_worker_command = ("{} {} "
-                            "--node-ip-address={} "
-                            "--object-store-name={} "
-                            "--raylet-name={} "
-                            "--redis-address={}".format(
-                                sys.executable, worker_path, node_ip_address,
-                                plasma_store_name, raylet_name, redis_address))
+    # Create the python command that the Raylet will use to start workers.
+    start_python_worker_command = ("{} {} "
+                                   "--node-ip-address={} "
+                                   "--object-store-name={} "
+                                   "--raylet-name={} "
+                                   "--redis-address={}".format(
+                                   sys.executable, worker_path, node_ip_address,
+                                   plasma_store_name, raylet_name, redis_address))
+
+    # Create the java command.  This is just a placeholder.
+    start_java_worker_command = ""
 
     command = [
         RAYLET_EXECUTABLE,
@@ -990,8 +993,9 @@ def start_raylet(redis_address,
         gcs_ip_address,
         gcs_port,
         str(num_workers),
-        start_worker_command,
         resource_argument,
+        start_java_worker_command,
+        start_python_worker_command
     ]
 
     if use_valgrind:

--- a/src/ray/raylet/main.cc
+++ b/src/ray/raylet/main.cc
@@ -6,7 +6,7 @@
 
 #ifndef RAYLET_TEST
 int main(int argc, char *argv[]) {
-  RAY_CHECK(argc == 9);
+  RAY_CHECK(argc == 10);
 
   const std::string raylet_socket_name = std::string(argv[1]);
   const std::string store_socket_name = std::string(argv[2]);
@@ -14,8 +14,9 @@ int main(int argc, char *argv[]) {
   const std::string redis_address = std::string(argv[4]);
   int redis_port = std::stoi(argv[5]);
   int num_initial_workers = std::stoi(argv[6]);
-  const std::string worker_command = std::string(argv[7]);
-  const std::string static_resource_list = std::string(argv[8]);
+  const std::string static_resource_list = std::string(argv[7]);
+  const std::string java_worker_command = std::string(argv[8]);
+  const std::string python_worker_command = std::string(argv[9]);
 
   // Configuration for the node manager.
   ray::raylet::NodeManagerConfig node_manager_config;
@@ -38,6 +39,13 @@ int main(int argc, char *argv[]) {
   node_manager_config.num_workers_per_process =
       RayConfig::instance().num_workers_per_process();
   // Use a default worker that can execute empty tasks with dependencies.
+
+  std::string worker_command;
+  if (!java_worker_command.empty()) {
+    worker_command = java_worker_command;
+  } else if (!python_worker_command.empty()) {
+    worker_command = python_worker_command;
+  }
 
   std::istringstream iss(worker_command);
   std::vector<std::string> results(std::istream_iterator<std::string>{iss},


### PR DESCRIPTION
<!--
Thank you for your contribution!

Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request.
-->

## What do these changes do?
For supporting multi-language, raylet should receive different command line arguments to start itself.

In java, we should start `raylet` by the command as blew:
```
raylet raylet_socket_name store_socket_name node_ip_address redis_address redis_port num_initial_workers static_resource_list java_worker_command ""
```

Note:The last argument is `python_worker_command`. In java, it must be empty string right now.

Similarly, we should start `raylet` in python by this command:
```
raylet raylet_socket_name store_socket_name node_ip_address redis_address redis_port num_initial_workers static_resource_list  "" python_worker_command
```

<!-- Please give a short brief about these changes. -->

## Related issue number
N/A
<!-- Are there any issues opened that will be resolved by merging this change? -->
