### PR TITLE
[WIP] Fix actor reconstruction

### DIFF
--- a/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
+++ b/java/test/src/main/java/org/ray/api/test/ActorReconstructionTest.java
@@ -47,9 +47,6 @@ public class ActorReconstructionTest extends BaseTest {
 
   public void testActorReconstruction() throws InterruptedException, IOException {
     TestUtils.skipTestUnderSingleProcess();
-    // TODO (kfstorm): Actor reconstruction is currently not supporeted in direct actor call mode.
-    // Will re-enable the test once the issue got fixed.
-    TestUtils.skipTestIfDirectActorCallEnabled();
     ActorCreationOptions options =
         new ActorCreationOptions.Builder().setMaxReconstructions(1).createActorCreationOptions();
     RayActor<Counter> actor = Ray.createActor(Counter::new, options);
@@ -130,10 +127,6 @@ public class ActorReconstructionTest extends BaseTest {
 
   public void testActorCheckpointing() throws IOException, InterruptedException {
     TestUtils.skipTestUnderSingleProcess();
-    // TODO (kfstorm): In direct actor call mode, the actor creation task is not pushed to raylet.
-    // But to save an actor checkpoint, raylet needs to know about this the actor. Will re-enable
-    // the test once the issue got fixed.
-    TestUtils.skipTestIfDirectActorCallEnabled();
     ActorCreationOptions options =
         new ActorCreationOptions.Builder().setMaxReconstructions(1).createActorCreationOptions();
     RayActor<CheckpointableCounter> actor = Ray.createActor(CheckpointableCounter::new, options);

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -125,7 +125,8 @@ bool WorkerContext::CurrentThreadIsMain() const {
 }
 
 bool WorkerContext::ShouldReleaseResourcesOnBlockingCalls() const {
-  return !CurrentActorIsDirectCall() && CurrentThreadIsMain();
+  return worker_type_ != WorkerType::DRIVER &&
+      !CurrentActorIsDirectCall() && CurrentThreadIsMain();
 }
 
 bool WorkerContext::CurrentActorIsDirectCall() const {

--- a/src/ray/core_worker/context.cc
+++ b/src/ray/core_worker/context.cc
@@ -125,8 +125,8 @@ bool WorkerContext::CurrentThreadIsMain() const {
 }
 
 bool WorkerContext::ShouldReleaseResourcesOnBlockingCalls() const {
-  return worker_type_ != WorkerType::DRIVER &&
-      !CurrentActorIsDirectCall() && CurrentThreadIsMain();
+  return worker_type_ != WorkerType::DRIVER && !CurrentActorIsDirectCall() &&
+         CurrentThreadIsMain();
 }
 
 bool WorkerContext::CurrentActorIsDirectCall() const {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -100,14 +100,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
   // Initialize gcs client.
   gcs_client_ = std::make_shared<gcs::RedisGcsClient>(gcs_options);
   RAY_CHECK_OK(gcs_client_->Connect(io_service_));
-  direct_actor_table_subscriber_ = std::unique_ptr<
-      gcs::SubscriptionExecutor<ActorID, gcs::ActorTableData, gcs::DirectActorTable>>(
-      new gcs::SubscriptionExecutor<ActorID, gcs::ActorTableData, gcs::DirectActorTable>(
-          gcs_client_->direct_actor_table()));
-
-  actor_manager_ =
-      std::unique_ptr<ActorManager>(new ActorManager(gcs_client_->direct_actor_table()));
-
+  
   // Initialize profiler.
   profiler_ = std::make_shared<worker::Profiler>(worker_context_, node_ip_address,
                                                  io_service_, gcs_client_);
@@ -179,7 +172,8 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       ref_counting_enabled ? reference_counter_ : nullptr, local_raylet_client_));
 
   task_manager_.reset(new TaskManager(
-      memory_store_, actor_manager_, [this](const TaskSpecification &spec) {
+      memory_store_, nullptr,
+      [this](const TaskSpecification &spec) {
         // Retry after a delay to emulate the existing Raylet reconstruction
         // behaviour. TODO(ekl) backoff exponentially.
         RAY_LOG(ERROR) << "Will resubmit task after a 5 second delay: "
@@ -283,14 +277,14 @@ void CoreWorker::SetCurrentTaskId(const TaskID &task_id) {
   if (actor_id_.IsNil() && task_id.IsNil()) {
     absl::MutexLock lock(&actor_handles_mutex_);
     for (const auto &handle : actor_handles_) {
-      RAY_CHECK_OK(direct_actor_table_subscriber_->AsyncUnsubscribe(
-          gcs_client_->client_table().GetLocalClientId(), handle.first, nullptr));
+      RAY_CHECK_OK(gcs_client_->Actors().AsyncUnsubscribe(handle.first, nullptr));
     }
     actor_handles_.clear();
   }
 }
 
 void CoreWorker::ReportActiveObjectIDs() {
+#if 0
   std::unordered_set<ObjectID> active_object_ids;
   size_t max_active = RayConfig::instance().raylet_max_active_object_ids();
   if (max_active > 0) {
@@ -312,6 +306,7 @@ void CoreWorker::ReportActiveObjectIDs() {
       boost::asio::chrono::milliseconds(
           RayConfig::instance().worker_heartbeat_timeout_milliseconds()));
   heartbeat_timer_.async_wait(boost::bind(&CoreWorker::ReportActiveObjectIDs, this));
+#endif
 }
 
 void CoreWorker::InternalHeartbeat() {
@@ -781,8 +776,20 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle) {
     // Register a callback to handle actor notifications.
     auto actor_notification_callback = [this](const ActorID &actor_id,
                                               const gcs::ActorTableData &actor_data) {
-      RAY_CHECK(actor_data.state() != gcs::ActorTableData::RECONSTRUCTING);
-      if (actor_data.state() == gcs::ActorTableData::DEAD) {
+      if (actor_data.state() == gcs::ActorTableData::RECONSTRUCTING) {
+        absl::MutexLock lock(&actor_handles_mutex_);
+        auto it = actor_handles_.find(actor_id);
+        RAY_CHECK(it != actor_handles_.end());
+        if (it->second->IsDirectCallActor()) {
+          // We have to reset the actor handle since the next instance of the
+          // actor will not have the last sequence number that we sent.
+          // TODO: Remove the check for direct calls. We do not reset for the
+          // raylet codepath because it tries to replay all tasks since the
+          // last actor checkpoint.
+          it->second->Reset();
+        }
+        direct_actor_submitter_->DisconnectActor(actor_id, false);
+      } else if (actor_data.state() == gcs::ActorTableData::DEAD) {
         direct_actor_submitter_->DisconnectActor(actor_id, true);
 
         ActorHandle *actor_handle = nullptr;
@@ -804,9 +811,8 @@ bool CoreWorker::AddActorHandle(std::unique_ptr<ActorHandle> actor_handle) {
                     << ClientID::FromBinary(actor_data.address().raylet_id());
     };
 
-    RAY_CHECK_OK(direct_actor_table_subscriber_->AsyncSubscribe(
-        gcs_client_->client_table().GetLocalClientId(), actor_id,
-        actor_notification_callback, nullptr));
+    RAY_CHECK_OK(gcs_client_->Actors().AsyncSubscribe(
+        actor_id, actor_notification_callback, nullptr));
   }
   return inserted;
 }

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -296,7 +296,6 @@ void CoreWorker::SetCurrentTaskId(const TaskID &task_id) {
 }
 
 void CoreWorker::ReportActiveObjectIDs() {
-#if 0
   std::unordered_set<ObjectID> active_object_ids;
   size_t max_active = RayConfig::instance().raylet_max_active_object_ids();
   if (max_active > 0) {
@@ -318,7 +317,6 @@ void CoreWorker::ReportActiveObjectIDs() {
       boost::asio::chrono::milliseconds(
           RayConfig::instance().worker_heartbeat_timeout_milliseconds()));
   heartbeat_timer_.async_wait(boost::bind(&CoreWorker::ReportActiveObjectIDs, this));
-#endif
 }
 
 void CoreWorker::InternalHeartbeat() {

--- a/src/ray/core_worker/core_worker.cc
+++ b/src/ray/core_worker/core_worker.cc
@@ -100,7 +100,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
   // Initialize gcs client.
   gcs_client_ = std::make_shared<gcs::RedisGcsClient>(gcs_options);
   RAY_CHECK_OK(gcs_client_->Connect(io_service_));
-  
+
   // Initialize profiler.
   profiler_ = std::make_shared<worker::Profiler>(worker_context_, node_ip_address,
                                                  io_service_, gcs_client_);
@@ -185,8 +185,7 @@ CoreWorker::CoreWorker(const WorkerType worker_type, const Language language,
       ref_counting_enabled ? reference_counter_ : nullptr, local_raylet_client_));
 
   task_manager_.reset(new TaskManager(
-      memory_store_, reference_counter_, nullptr,
-      [this](const TaskSpecification &spec) {
+      memory_store_, reference_counter_, nullptr, [this](const TaskSpecification &spec) {
         // Retry after a delay to emulate the existing Raylet reconstruction
         // behaviour. TODO(ekl) backoff exponentially.
         RAY_LOG(ERROR) << "Will resubmit task after a 5 second delay: "

--- a/src/ray/core_worker/core_worker.h
+++ b/src/ray/core_worker/core_worker.h
@@ -557,11 +557,6 @@ class CoreWorker {
   // Client to the GCS shared by core worker interfaces.
   std::shared_ptr<gcs::RedisGcsClient> gcs_client_;
 
-  // Client to listen to direct actor events.
-  std::unique_ptr<
-      gcs::SubscriptionExecutor<ActorID, gcs::ActorTableData, gcs::DirectActorTable>>
-      direct_actor_table_subscriber_;
-
   // Client to the raylet shared by core worker interfaces. This needs to be a
   // shared_ptr for direct calls because we can lease multiple workers through
   // one client, and we need to keep the connection alive until we return all
@@ -592,9 +587,6 @@ class CoreWorker {
 
   // Tracks the currently pending tasks.
   std::shared_ptr<TaskManager> task_manager_;
-
-  // Interface for publishing actor creation.
-  std::shared_ptr<ActorManager> actor_manager_;
 
   // Interface to submit tasks directly to other actors.
   std::unique_ptr<CoreWorkerDirectActorTaskSubmitter> direct_actor_submitter_;

--- a/src/ray/core_worker/task_manager.cc
+++ b/src/ray/core_worker/task_manager.cc
@@ -62,11 +62,6 @@ void TaskManager::CompletePendingTask(const TaskID &task_id,
           in_memory_store_->Put(RayObject(data_buffer, metadata_buffer), object_id));
     }
   }
-
-  if (spec.IsActorCreationTask()) {
-    RAY_CHECK(actor_addr != nullptr);
-    actor_manager_->PublishCreatedActor(spec, *actor_addr);
-  }
 }
 
 void TaskManager::PendingTaskFailed(const TaskID &task_id, rpc::ErrorType error_type,
@@ -134,9 +129,6 @@ void TaskManager::MarkPendingTaskFailed(const TaskID &task_id,
         task_id, /*index=*/i + 1,
         /*transport_type=*/static_cast<int>(TaskTransportType::DIRECT));
     RAY_CHECK_OK(in_memory_store_->Put(RayObject(error_type), object_id));
-  }
-  if (spec.IsActorCreationTask()) {
-    actor_manager_->PublishTerminatedActor(spec);
   }
 }
 

--- a/src/ray/core_worker/test/core_worker_test.cc
+++ b/src/ray/core_worker/test/core_worker_test.cc
@@ -993,18 +993,16 @@ TEST_F(TwoNodeTest, TestDirectActorTaskCrossNodes) {
   TestActorTask(resources, true);
 }
 
-// TODO(ekl) re-enable once reconstruction is implemented
-// TEST_F(SingleNodeTest, TestDirectActorTaskLocalReconstruction) {
-//  std::unordered_map<std::string, double> resources;
-//  TestActorReconstruction(resources, true);
-//}
+TEST_F(SingleNodeTest, TestDirectActorTaskLocalReconstruction) {
+  std::unordered_map<std::string, double> resources;
+  TestActorReconstruction(resources, true);
+}
 
-// TODO(ekl) re-enable once reconstruction is implemented
-// TEST_F(TwoNodeTest, TestDirectActorTaskCrossNodesReconstruction) {
-//  std::unordered_map<std::string, double> resources;
-//  resources.emplace("resource1", 1);
-//  TestActorReconstruction(resources, true);
-//}
+TEST_F(TwoNodeTest, TestDirectActorTaskCrossNodesReconstruction) {
+  std::unordered_map<std::string, double> resources;
+  resources.emplace("resource1", 1);
+  TestActorReconstruction(resources, true);
+}
 
 TEST_F(SingleNodeTest, TestDirectActorTaskLocalFailure) {
   std::unordered_map<std::string, double> resources;

--- a/src/ray/core_worker/transport/direct_actor_transport.cc
+++ b/src/ray/core_worker/transport/direct_actor_transport.cc
@@ -146,6 +146,7 @@ void CoreWorkerDirectTaskReceiver::Init(raylet::RayletClient &raylet_client,
   waiter_.reset(new DependencyWaiterImpl(raylet_client));
   rpc_address_ = rpc_address;
   client_factory_ = client_factory;
+  local_raylet_client_ = raylet_client;
 }
 
 void CoreWorkerDirectTaskReceiver::SetMaxActorConcurrency(int max_concurrency) {
@@ -254,6 +255,12 @@ void CoreWorkerDirectTaskReceiver::HandlePushTask(
                                         result->GetMetadata()->Size());
           }
         }
+      }
+
+      if (task_spec.IsActorCreationTask()) {
+        RAY_LOG(INFO) << "finish actor creation task " << task_spec.TaskId()
+                      << ", actor_id: " << task_spec.ActorCreationId();
+        RAY_CHECK_OK(local_raylet_client_->TaskDone());
       }
     }
     if (status.IsSystemExit()) {

--- a/src/ray/core_worker/transport/direct_actor_transport.h
+++ b/src/ray/core_worker/transport/direct_actor_transport.h
@@ -499,6 +499,8 @@ class CoreWorkerDirectTaskReceiver {
   /// The fiber semaphore used to limit the number of concurrent fibers
   /// running at once.
   std::shared_ptr<FiberRateLimiter> fiber_rate_limiter_;
+
+  boost::optional<raylet::RayletClient &> local_raylet_client_;
 };
 
 }  // namespace ray

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -12,7 +12,10 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
     // Note that the dependencies in the task spec are mutated to only contain
     // plasma dependencies after ResolveDependencies finishes.
     const SchedulingKey scheduling_key(task_spec.GetSchedulingClass(),
-                                       task_spec.GetDependencies());
+                                       task_spec.GetDependencies(),
+                                       task_spec.IsActorCreationTask()
+                                          ? task_spec.ActorCreationId()
+                                          : ActorID::Nil());
     auto it = task_queues_.find(scheduling_key);
     if (it == task_queues_.end()) {
       it = task_queues_.emplace(scheduling_key, std::deque<TaskSpecification>()).first;

--- a/src/ray/core_worker/transport/direct_task_transport.cc
+++ b/src/ray/core_worker/transport/direct_task_transport.cc
@@ -11,11 +11,9 @@ Status CoreWorkerDirectTaskSubmitter::SubmitTask(TaskSpecification task_spec) {
     absl::MutexLock lock(&mu_);
     // Note that the dependencies in the task spec are mutated to only contain
     // plasma dependencies after ResolveDependencies finishes.
-    const SchedulingKey scheduling_key(task_spec.GetSchedulingClass(),
-                                       task_spec.GetDependencies(),
-                                       task_spec.IsActorCreationTask()
-                                          ? task_spec.ActorCreationId()
-                                          : ActorID::Nil());
+    const SchedulingKey scheduling_key(
+        task_spec.GetSchedulingClass(), task_spec.GetDependencies(),
+        task_spec.IsActorCreationTask() ? task_spec.ActorCreationId() : ActorID::Nil());
     auto it = task_queues_.find(scheduling_key);
     if (it == task_queues_.end()) {
       it = task_queues_.emplace(scheduling_key, std::deque<TaskSpecification>()).first;

--- a/src/ray/core_worker/transport/direct_task_transport.h
+++ b/src/ray/core_worker/transport/direct_task_transport.h
@@ -26,8 +26,9 @@ typedef std::function<std::shared_ptr<WorkerLeaseInterface>(const std::string &i
 // (encapsulated in SchedulingClass) to defer resource allocation decisions to the raylet
 // and ensure fairness between different tasks, as well as plasma task dependencies as
 // a performance optimization because the raylet will fetch plasma dependencies to the
-// scheduled worker.
-using SchedulingKey = std::pair<SchedulingClass, std::vector<ObjectID>>;
+// scheduled worker. It's also keyed on actor ID to ensure the actor creation task
+// would always request a new worker lease.
+using SchedulingKey = std::tuple<SchedulingClass, std::vector<ObjectID>, ActorID>;
 
 // This class is thread-safe.
 class CoreWorkerDirectTaskSubmitter {

--- a/src/ray/gcs/redis_actor_info_accessor.cc
+++ b/src/ray/gcs/redis_actor_info_accessor.cc
@@ -84,7 +84,8 @@ Status RedisActorInfoAccessor::AsyncUpdate(
     // RECONSTRUCTING or DEAD entries have an odd index.
     log_length += 1;
   }
-
+  RAY_LOG(DEBUG) << "AsyncUpdate actor state to " << data_ptr->state()
+                << ", actor id: " << actor_id << ", log_length:" << log_length;
   auto on_success = [callback](RedisGcsClient *client, const ActorID &actor_id,
                                const ActorTableData &data) {
     // If we successfully appended a record to the GCS table of the actor that

--- a/src/ray/gcs/redis_actor_info_accessor.cc
+++ b/src/ray/gcs/redis_actor_info_accessor.cc
@@ -85,7 +85,7 @@ Status RedisActorInfoAccessor::AsyncUpdate(
     log_length += 1;
   }
   RAY_LOG(DEBUG) << "AsyncUpdate actor state to " << data_ptr->state()
-                << ", actor id: " << actor_id << ", log_length:" << log_length;
+                 << ", actor id: " << actor_id << ", log_length:" << log_length;
   auto on_success = [callback](RedisGcsClient *client, const ActorID &actor_id,
                                const ActorTableData &data) {
     // If we successfully appended a record to the GCS table of the actor that

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -2292,10 +2292,11 @@ void NodeManager::AssignTask(const std::shared_ptr<Worker> &worker, const Task &
     task.OnDispatch()(worker, initial_config_.node_manager_address, worker->Port(),
                       worker->WorkerId(),
                       spec.IsActorCreationTask() ? worker->GetLifetimeResourceIds()
-                                                 : worker->GetTaskResourceIds());                                          
+                                                 : worker->GetTaskResourceIds());
     post_assign_callbacks->push_back([this, worker, task_id]() {
-      RAY_LOG(DEBUG) << "Finished assigning task " << task_id
-                     << " to worker " << worker->WorkerId();;   
+      RAY_LOG(DEBUG) << "Finished assigning task " << task_id << " to worker "
+                     << worker->WorkerId();
+      ;
       FinishAssignTask(worker, task_id, /*success=*/true);
     });
   } else {
@@ -2419,8 +2420,7 @@ std::shared_ptr<ActorTableData> NodeManager::CreateActorTableDataFromCreationTas
   actor_info_ptr->mutable_address()->set_port(port);
   actor_info_ptr->mutable_address()->set_raylet_id(
       gcs_client_->client_table().GetLocalClientId().Binary());
-  actor_info_ptr->mutable_address()->set_worker_id(
-      worker_id.Binary());
+  actor_info_ptr->mutable_address()->set_worker_id(worker_id.Binary());
   actor_info_ptr->set_state(ActorTableData::ALIVE);
   return actor_info_ptr;
 }
@@ -2525,8 +2525,8 @@ void NodeManager::FinishAssignedActorTask(Worker &worker, const Task &task) {
 
 void NodeManager::FinishAssignedActorCreationTask(const ActorID &parent_actor_id,
                                                   const TaskSpecification &task_spec,
-                                                  bool resumed_from_checkpoint,
-                                                  int port, const WorkerID &worker_id) {
+                                                  bool resumed_from_checkpoint, int port,
+                                                  const WorkerID &worker_id) {
   // Notify the other node managers that the actor has been created.
   const ActorID actor_id = task_spec.ActorCreationId();
   auto new_actor_info = CreateActorTableDataFromCreationTask(task_spec, port, worker_id);
@@ -2890,7 +2890,7 @@ void NodeManager::ForwardTask(
 
 void NodeManager::FinishAssignTask(const std::shared_ptr<Worker> &worker,
                                    const TaskID &task_id, bool success) {
-  RAY_LOG(DEBUG) << "FinishAssignTask: " << task_id;                                        
+  RAY_LOG(DEBUG) << "FinishAssignTask: " << task_id;
   // Remove the ASSIGNED task from the READY queue.
   Task assigned_task;
   TaskState state;
@@ -2898,7 +2898,7 @@ void NodeManager::FinishAssignTask(const std::shared_ptr<Worker> &worker,
     // TODO(edoakes): should we be failing silently here?
     return;
   }
-  RAY_CHECK(state == TaskState::READY);         
+  RAY_CHECK(state == TaskState::READY);
   if (success) {
     auto spec = assigned_task.GetTaskSpecification();
     // We successfully assigned the task to the worker.
@@ -2910,7 +2910,7 @@ void NodeManager::FinishAssignTask(const std::shared_ptr<Worker> &worker,
     // the actor's current execution dependency.
 
     // Mark the task as running.
-    // (See design_docs/task_states.rst for the state transition diagram.) 
+    // (See design_docs/task_states.rst for the state transition diagram.)
     local_queues_.QueueTasks({assigned_task}, TaskState::RUNNING);
     // Notify the task dependency manager that we no longer need this task's
     // object dependencies.

--- a/src/ray/raylet/node_manager.cc
+++ b/src/ray/raylet/node_manager.cc
@@ -1562,7 +1562,7 @@ void NodeManager::HandleWorkerLeaseRequest(const rpc::WorkerLeaseRequest &reques
     auto request_resources =
         task.GetTaskSpecification().GetRequiredResources().GetResourceMap();
     auto work = std::make_pair(
-        [this, request_resources, reply, send_reply_callback, is_actor_creation_task](
+        [this, request_resources, reply, send_reply_callback](
             std::shared_ptr<Worker> worker, ClientID spillback_to, std::string address,
             int port) {
           if (worker != nullptr) {
@@ -1594,7 +1594,7 @@ void NodeManager::HandleWorkerLeaseRequest(const rpc::WorkerLeaseRequest &reques
   RAY_LOG(DEBUG) << "Worker lease request " << task.GetTaskSpecification().TaskId();
   TaskID task_id = task.GetTaskSpecification().TaskId();
   task.OnDispatchInstead(
-      [this, task_id, reply, send_reply_callback, is_actor_creation_task](
+      [this, task_id, reply, send_reply_callback](
           const std::shared_ptr<void> granted, const std::string &address, int port,
           const WorkerID &worker_id, const ResourceIdSet &resource_ids) {
         RAY_LOG(DEBUG) << "Worker lease request DISPATCH " << task_id;

--- a/src/ray/raylet/node_manager.h
+++ b/src/ray/raylet/node_manager.h
@@ -231,7 +231,7 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// actor.
   /// \param worker The port that the actor is listening on.
   std::shared_ptr<ActorTableData> CreateActorTableDataFromCreationTask(
-      const TaskSpecification &task_spec, int port);
+      const TaskSpecification &task_spec, int port, const WorkerID &worker_id);
   /// Handle a worker finishing an assigned actor task or actor creation task.
   /// \param worker The worker that finished the task.
   /// \param task The actor task or actor creation task.
@@ -249,7 +249,8 @@ class NodeManager : public rpc::NodeManagerServiceHandler {
   /// \return Void.
   void FinishAssignedActorCreationTask(const ActorID &parent_actor_id,
                                        const TaskSpecification &task_spec,
-                                       bool resumed_from_checkpoint, int port);
+                                       bool resumed_from_checkpoint, int port,
+                                       const WorkerID &worker_id);
   /// Make a placement decision for placeable tasks given the resource_map
   /// provided. This will perform task state transitions and task forwarding.
   ///


### PR DESCRIPTION
## Why are these changes needed?

Currently, actor reconstruction is no longer supported after actor creation task is changed to use direct task call. This PR lets raylet to manage the actor lifecycle, including publishing the actor created, reconstructed, dead events, as well as reconstructing the actors. The current limitation is the support for reconstruction during actor creation is not complete, which can be addressed by a follow up PR.

## Related issue number

## Checks

- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://ray.readthedocs.io/en/latest/.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failure rates at https://ray-travis-tracker.herokuapp.com/.
