### PR TITLE
[RuntimeEnv] Use the same arguments for starting podman containers

### DIFF
--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -140,7 +140,7 @@ def _modify_container_context_impl(
     # we need 'sudo' and 'admin', mount logs
     if container_option.get("sudo"):
         container_command = ["sudo", "-E"] + container_command
-        
+
     container_command.append("-u")
     # we set the user in the container, default is 'admin'
     user = container_option.get("user")


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

Currently, when using Nydus, we pass different arguments for running podman. Actually, those arguments can be unified. And different arguments are passed through container running options


## Why are these changes needed?

To fix podman running issue

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(
