### PR TITLE
ci/auto sync

### DIFF
--- a/.github/workflows/auto-create-pr.yaml
+++ b/.github/workflows/auto-create-pr.yaml
@@ -4,6 +4,28 @@ on:
   schedule:
     - cron: '0 1 * * *'
 
+  workflow_dispatch:
+    inputs:
+      source_branch:
+        description: 'Source branch to merge from'
+        required: true
+        default: 'master'
+        type: choice
+        options:
+          - master
+      target_branch:
+        description: 'Target branch to merge into'
+        required: true
+        default: 'main'
+        type: choice
+        options:
+          - main
+      assignees:
+        description: 'Assignees for the PR'
+        required: false
+        default: 'mingcheng'
+        type: string
+
 jobs:
   create-merge-pr:
     runs-on: ubuntu-latest
@@ -15,8 +37,8 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
-          branch: master
-          base: main
+          branch: ${{ github.event.inputs.source_branch || 'master' }}
+          base: ${{ github.event.inputs.target_branch || 'main' }}
           title: '🔄 Daily merge: upstream master branch to main ($(date +%Y-%m-%d))'
           body: |
             ## This is auto-generated Merge Pull Request
@@ -24,8 +46,8 @@ jobs:
             This PR is created automatically by a GitHub Action to merge the latest changes from the upstream `master` branch into the `main` branch.
 
             📅 **Created**: $(date +%Y-%m-%d)
-            🔀 **Merge direction**: upstream master → main
-            🤖 **Created by**: GitHub Actions
+            🔀 **Merge direction**: upstream ${{ github.event.inputs.source_branch || 'master' }} → ${{ github.event.inputs.target_branch || 'main' }}
+            🤖 **Trigger by**: ${{ github.event_name == 'workflow_dispatch' && 'Manual' || 'Scheduled' }}
 
             Please review before merging.
           labels: |
@@ -33,4 +55,4 @@ jobs:
             merge
           draft: false
           delete-branch: false
-          assignees: mingcheng
+          assignees: ${{ github.event.inputs.assignees || 'mingcheng' }}


### PR DESCRIPTION
- add workflow_dispatch trigger with configurable parameters
- support custom source and target branch selection
- enable dynamic assignee configuration for PRs
- update PR title and body to reflect selected branches
- add trigger type indication in PR description

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Refine auto-create-pr workflow to support manual triggers with configurable parameters and dynamic PR details

CI:
- Add workflow_dispatch trigger with inputs for source_branch, target_branch, and assignees
- Use provided inputs to set branch, base, and assignees in the create-pull-request action
- Update PR body to show merge direction dynamically and indicate trigger type