### PR TITLE
fix: set PR draft status to false and add branch suffix for clarity

### DIFF
--- a/.github/workflows/auto-create-pr.yaml
+++ b/.github/workflows/auto-create-pr.yaml
@@ -54,6 +54,7 @@ jobs:
           labels: |
             automated
             merge
-          draft: always-true
+          draft: false
+          branch-suffix: short-commit-hash
           delete-branch: false
           assignees: ${{ github.event.inputs.assignees || 'mingcheng' }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Update the GitHub Actions auto-create-pr workflow to generate non-draft pull requests and include a commit-based branch suffix for clarity.

Enhancements:
- Disable draft status for auto-created PRs
- Append a short commit hash as branch suffix for automatically created PR branches