### PR TITLE
fix: update auto-create PR workflow to reset promotion branch and ena…

### DIFF
--- a/.github/workflows/auto-create-pr.yaml
+++ b/.github/workflows/auto-create-pr.yaml
@@ -33,11 +33,15 @@ jobs:
         with:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
+      - name: Reset promotion branch
+        run: |
+          git fetch origin ${{ github.event.inputs.source_branch || 'master' }}:${{ github.event.inputs.source_branch || 'master' }}
+          git reset --hard ${{ github.event.inputs.source_branch || 'master' }}
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
-          branch: ${{ github.event.inputs.source_branch || 'master' }}
+          # branch: ${{ github.event.inputs.source_branch || 'master' }}
           base: ${{ github.event.inputs.target_branch || 'main' }}
           title: '🔄 Daily merge: upstream master branch to main ($(date +%Y-%m-%d))'
           body: |
@@ -56,5 +60,5 @@ jobs:
             merge
           draft: false
           branch-suffix: short-commit-hash
-          delete-branch: false
+          delete-branch: true
           assignees: ${{ github.event.inputs.assignees || 'mingcheng' }}


### PR DESCRIPTION
…ble branch deletion

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Update the auto-create-pr GitHub Actions workflow to ensure the promotion branch is reset to the latest source branch, drop the explicit branch setting, and enable branch deletion post-merge

CI:
- Add a step to reset the promotion branch to the latest source branch commit before creating a PR
- Remove the explicit branch parameter from the create-pull-request action
- Enable automatic deletion of the branch after the PR is merged