### PR TITLE
fix: update default assignee and enhance variable preparation in auto…

### DIFF
--- a/.github/workflows/auto-create-pr.yaml
+++ b/.github/workflows/auto-create-pr.yaml
@@ -22,44 +22,62 @@ on:
       assignees:
         description: 'Assignees for the PR'
         required: false
-        default: 'mingcheng'
+        default: 'ffbin'
         type: string
 
 jobs:
   create-merge-pr:
     runs-on: ubuntu-latest
+    # Put commonly used values into job env so steps can reference them clearly
+    env:
+      # these will be overridden by the step that writes to $GITHUB_ENV when the job runs
+      SOURCE_BRANCH: ${{ github.event.inputs.source_branch || 'master' }}
+      TARGET_BRANCH: ${{ github.event.inputs.target_branch || 'main' }}
+      ASSIGNEES: ${{ github.event.inputs.assignees || 'ffbin' }}
     steps:
       - uses: actions/checkout@v4
         with:
           token: ${{ secrets.GH_TOKEN }}
           fetch-depth: 0
-      - name: Set current date
-        run: echo "DATE=$(date +%Y-%m-%d)" >> $GITHUB_ENV
-      - name: Reset promotion branch
+      - name: Prepare variables
         run: |
-          git fetch origin ${{ github.event.inputs.source_branch || 'master' }}:${{ github.event.inputs.source_branch || 'master' }}
-          git reset --hard ${{ github.event.inputs.source_branch || 'master' }}
+          # Use UTC date for consistency across runners
+          echo "DATE=$(date -u +%Y-%m-%d)" >> $GITHUB_ENV
+
+          # Normalize inputs into env vars so later steps can use $SOURCE_BRANCH etc.
+          echo "SOURCE_BRANCH=${{ github.event.inputs.source_branch || 'master' }}" >> $GITHUB_ENV
+          echo "TARGET_BRANCH=${{ github.event.inputs.target_branch || 'main' }}" >> $GITHUB_ENV
+          echo "ASSIGNEES=${{ github.event.inputs.assignees || 'ffbin' }}" >> $GITHUB_ENV
+
+      - name: Fetch source branch and checkout
+        run: |
+          # Fetch only the source branch
+          git fetch --no-tags origin "$SOURCE_BRANCH"
+
+          git reset --hard  "$SOURCE_BRANCH"
+          git status --porcelain --branch || true
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
-          # branch: ${{ github.event.inputs.source_branch || 'master' }}
-          base: ${{ github.event.inputs.target_branch || 'main' }}
-          title: '🔄 daily merge: upstream master branch to main ${{ env.DATE }}'
+          # create the branch from the current HEAD (we checked out 'promote')
+          # branch: auto-merge/${{ env.SOURCE_BRANCH }}-to-${{ env.TARGET_BRANCH }}
+          branch-suffix: ${{ env.DATE }}
+          base: ${{ env.TARGET_BRANCH }}
+          title: |
+            🔄 daily merge: ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} ${{ env.DATE }}
           body: |
-            ## This is auto-generated Merge Pull Request
-
-            This PR is created automatically by a GitHub Action to merge the latest changes from the upstream `master` branch into the `main` branch.
+            This Pull Request was created automatically to merge the latest changes from
+            `${{ env.SOURCE_BRANCH }}` into `${{ env.TARGET_BRANCH }}`.
 
             📅 **Created**: ${{ env.DATE }}
-            🔀 **Merge direction**: upstream ${{ github.event.inputs.source_branch || 'master' }} → ${{ github.event.inputs.target_branch || 'main' }}
-            🤖 **Trigger by**: ${{ github.event_name == 'workflow_dispatch' && 'Manual' || 'Scheduled' }}
+            🔀 **Merge direction**: `${{ env.SOURCE_BRANCH }}` → `${{ env.TARGET_BRANCH }}`
+            🤖 **Triggered by**: ${{ github.event_name == 'workflow_dispatch' && 'Manual' || 'Scheduled' }}
 
-            Please review before merging!
+            Please review and merge if everything looks good.
           labels: |
-            automated
-            merge
+            auto-generated
+            daily-merge
           draft: false
-          branch-suffix: short-commit-hash
           delete-branch: true
-          assignees: ${{ github.event.inputs.assignees || 'mingcheng' }}
+          assignees: ${{ env.ASSIGNEES }}


### PR DESCRIPTION
…-create PR workflow

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Refine the GitHub Actions auto-create-pr workflow by improving variable handling, branch checkout, and PR metadata formatting, and update the default assignee.

Bug Fixes:
- Update default PR assignee from mingcheng to ffbin

CI:
- Introduce job-level environment variables for source/target branches and assignees
- Consolidate date setting and input normalization into a single 'Prepare variables' step
- Add explicit 'Fetch source branch and checkout' step using UTC date
- Enhance the pull request creation step with dynamic title, branch suffix, labels, and formatted body