### PR TITLE
fix: update fetch command to correctly reference source branch in aut…

### DIFF
--- a/.github/workflows/auto-create-pr.yaml
+++ b/.github/workflows/auto-create-pr.yaml
@@ -52,10 +52,10 @@ jobs:
       - name: Fetch source branch and checkout
         run: |
           # Fetch only the source branch
-          git fetch --no-tags origin "$SOURCE_BRANCH"
-
+          git fetch --no-tags origin "$SOURCE_BRANCH:$SOURCE_BRANCH"
           git reset --hard  "$SOURCE_BRANCH"
           git status --porcelain --branch || true
+          
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:


### PR DESCRIPTION
…o-create PR workflow

<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Update the auto-create-pr GitHub Actions workflow to fetch the source branch with an explicit refspec and reset it for proper checkout.

Bug Fixes:
- Fix git fetch refspec in the auto-create-pr workflow to correctly fetch and checkout the source branch.

CI:
- Update GitHub Actions auto-create-pr workflow to use explicit refspec for fetching the source branch.