### PR TITLE
fix: comment out branch-suffix in PR creation step for clarity

### DIFF
--- a/.github/workflows/auto-create-pr.yaml
+++ b/.github/workflows/auto-create-pr.yaml
@@ -55,14 +55,14 @@ jobs:
           git fetch --no-tags origin "$SOURCE_BRANCH:$SOURCE_BRANCH"
           git reset --hard  "$SOURCE_BRANCH"
           git status --porcelain --branch || true
-          
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_TOKEN }}
           # create the branch from the current HEAD (we checked out 'promote')
           # branch: auto-merge/${{ env.SOURCE_BRANCH }}-to-${{ env.TARGET_BRANCH }}
-          branch-suffix: ${{ env.DATE }}
+          # branch-suffix: ${{ env.DATE }}
           base: ${{ env.TARGET_BRANCH }}
           title: |
             🔄 daily merge: ${{ env.SOURCE_BRANCH }} → ${{ env.TARGET_BRANCH }} ${{ env.DATE }}


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Enhancements:
- Comment out the branch-suffix setting in the create-pull-request step to remove the date suffix from automated branches.