### PR TITLE
[WIP] fix runtime env agent port conflict

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -976,11 +976,15 @@ class Node:
         s.bind(("", 0))
         port = s.getsockname()[1]
 
+        low_end = int(os.getenv("RAY_PORT_RANGE_LOW", 10000))
+        high_end = int(os.getenv("RAY_PORT_RANGE_HIGH", 11499))
+
+
         # Try to generate a port that is far above the 'next available' one.
         # This solves issue #8254 where GRPC fails because the port assigned
         # from this method has been used by a different process.
         for _ in range(ray_constants.NUM_PORT_RETRIES):
-            new_port = random.randint(port, 65535)
+            new_port = random.randint(low_end, high_end)
             if new_port in allocated_ports:
                 # This port is allocated for other usage already,
                 # so we shouldn't use it even if it's not in use right now.


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Restrict the random port selection for the runtime environment agent to a configurable range to avoid port conflicts.

Bug Fixes:
- Use RAY_PORT_RANGE_LOW and RAY_PORT_RANGE_HIGH environment variables (defaulting to 10000–11499) to bound the random port selection
- Prevent selecting ports outside the configured range instead of using the full ephemeral port range