### PR TITLE
🔄 daily merge: fix_runtime_env_port → upstream_2.46.0 2025-11-17

### DIFF
--- a/python/ray/_private/node.py
+++ b/python/ray/_private/node.py
@@ -976,11 +976,15 @@ class Node:
         s.bind(("", 0))
         port = s.getsockname()[1]
 
+        low_end = int(os.getenv("RAY_PORT_RANGE_LOW", 10000))
+        high_end = int(os.getenv("RAY_PORT_RANGE_HIGH", 11499))
+
+
         # Try to generate a port that is far above the 'next available' one.
         # This solves issue #8254 where GRPC fails because the port assigned
         # from this method has been used by a different process.
         for _ in range(ray_constants.NUM_PORT_RETRIES):
-            new_port = random.randint(port, 65535)
+            new_port = random.randint(low_end, high_end)
             if new_port in allocated_ports:
                 # This port is allocated for other usage already,
                 # so we shouldn't use it even if it's not in use right now.


### PR DESCRIPTION
This Pull Request was created automatically to merge the latest changes from `fix_runtime_env_port` into `upstream_2.46.0` branch.

📅 **Created**: 2025-11-17
🔀 **Merge direction**: `fix_runtime_env_port` → `upstream_2.46.0`
🤖 **Triggered by**: Manual

Please review and merge if everything looks good.

## Summary by Sourcery

Merge fix_runtime_env_port branch into upstream_2.46.0 to support configurable port ranges for runtime environment.

Enhancements:
- Introduce RAY_PORT_RANGE_LOW and RAY_PORT_RANGE_HIGH environment variables to define the port selection bounds in node._get_unused_port
- Replace unbounded random port selection with a range-based allocation to avoid GRPC port conflicts