### PR TITLE
[RuntimeEnv] Support custom podman command

### DIFF
--- a/python/ray/tests/runtime_env_container/test_image_uri.py
+++ b/python/ray/tests/runtime_env_container/test_image_uri.py
@@ -1,0 +1,16 @@
+import asyncio
+import logging
+from ray._private.runtime_env.image_uri import _apply_output_filter
+
+
+def test_apply_output_filter_with_grep_v_head():    
+    logger = logging.getLogger(__name__)
+    worker_path = """time=1234567890
+                    /path/to/worker.py
+                    time=1234567891
+                    /other/path/file.py
+                    time=1234567892
+                    /final/path/worker.py"""
+    
+    result = asyncio.run(_apply_output_filter(logger, worker_path, "grep -v '^time=' | head -1")) 
+    assert result.strip() == "/path/to/worker.py"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?

<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number

<!-- For example: "Closes #1234" -->

## Checks

- [ ] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [ ] I've run `scripts/format.sh` to lint the changes in this PR.
- [ ] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [ ] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [ ] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [ ] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Add configurability and output filtering to Podman-based runtime env image handling and container startup.

Enhancements:
- Allow overriding the Podman image pull command via the RAY_PODMAN_PULL_CMD environment variable.
- Support filtering the Podman pull output to derive the worker path using the RAY_PODMAN_OUTPUT_FILTER environment variable.
- Allow customizing the container Python executable/command prefix with the RAY_PODMAN_CONTAINER_CMD environment variable.
- Propagate additional host environment variables into the container based on the RAY_PODMAN_EXTRA_ENV_KEYS environment variable.

Tests:
- Add a test for the output filtering helper to ensure it correctly extracts the worker path from noisy command output.