### PR TITLE
[Docker image] provide an example of prebuilt ant-ray Docker image

### DIFF
--- a/build-docker-ant.sh
+++ b/build-docker-ant.sh
@@ -2,6 +2,8 @@
 # shellcheck disable=SC2086
 # This script is for users to build docker images locally. It is most useful for users wishing to edit the
 # base-deps, or ray images. This script is *not* tested.
+# A pre-built image example, constructed following build-docker-ant.sh, is available on Alibaba Cloud Container Registry:
+# crpi-3wcszgxf0r7f5bmh.cn-hangzhou.personal.cr.aliyuncs.com/ant-ray/prebuilt
 
 GPU=""
 BASE_IMAGE="ubuntu:22.04"

--- a/python/ray/_private/runtime_env/image_uri.py
+++ b/python/ray/_private/runtime_env/image_uri.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import json
+import shlex
 from typing import List, Optional
 import ray
 import ray._private.runtime_env.constants as runtime_env_constants
@@ -26,22 +27,38 @@ default_logger = logging.getLogger(__name__)
 async def _create_impl(image_uri: str, logger: logging.Logger):
     # Pull image if it doesn't exist
     # Also get path to `default_worker.py` inside the image.
-    pull_image_cmd = [
-        "podman",
-        "run",
-        "--rm",
-        image_uri,
-        "python",
-        "-c",
-        (
-            "import ray._private.workers.default_worker as default_worker; "
-            "print(default_worker.__file__)"
-        ),
-    ]
-    logger.info("Pulling image %s", image_uri)
-    worker_path = await check_output_cmd(pull_image_cmd, logger=logger)
+    custom_pull_cmd = os.getenv("RAY_PODMAN_PULL_CMD", "")
+    if custom_pull_cmd:
+        logger.info("Using custom pull command: %s", custom_pull_cmd)
+        shell_cmd = ["sh", "-c", custom_pull_cmd]
+        worker_path = await check_output_cmd(shell_cmd, logger=logger)
+    else:
+        pull_image_cmd = [
+            "podman",
+            "run",
+            "--rm",
+            image_uri,
+            "python",
+            "-c",
+            (
+                "import ray._private.workers.default_worker as default_worker; "
+                "print(default_worker.__file__)"
+            ),
+        ]
+        logger.info("Pulling image %s", image_uri)
+        worker_path = await check_output_cmd(pull_image_cmd, logger=logger)
+
+    output_filter = os.getenv("RAY_PODMAN_OUTPUT_FILTER", "")
+    if output_filter:
+        worker_path = await _apply_output_filter(logger, worker_path, output_filter)
     return worker_path.strip()
 
+async def _apply_output_filter(logger, worker_path, output_filter):
+    safe_worker_path = shlex.quote(worker_path)
+    filter_cmd = ["sh", "-c", f"printf '%s' {safe_worker_path} | {output_filter}"]
+    filtered_path = await check_output_cmd(filter_cmd, logger=logger)
+    worker_path = filtered_path
+    return worker_path
 
 def _modify_container_context_impl(
     runtime_env: "RuntimeEnv",  # noqa: F821
@@ -157,9 +174,9 @@ def _modify_container_context_impl(
 
     redirected_pyenv_folder = None
     if container_install_ray or container_pip_packages:
-        container_to_host_mount_dict[
-            container_dependencies_installer_path
-        ] = get_dependencies_installer_path()
+        container_to_host_mount_dict[container_dependencies_installer_path] = (
+            get_dependencies_installer_path()
+        )
         if runtime_env_constants.RAY_PODMAN_UES_WHL_PACKAGE:
             container_to_host_mount_dict[get_ray_whl_dir()] = get_ray_whl_dir()
 
@@ -253,6 +270,16 @@ def _modify_context_impl(
     ray_tmp_dir: str,
 ):
     context.override_worker_entrypoint = worker_path
+    custom_container_cmd = os.getenv("RAY_PODMAN_CONTAINER_CMD", "")
+    if custom_container_cmd:
+        custom_container_cmd_str = custom_container_cmd.format(
+            ray_tmp_dir=ray_tmp_dir, image_uri=image_uri
+        )
+        logger.info(
+            f"Starting worker in container with prefix {custom_container_cmd_str}"
+        )
+        context.py_executable = custom_container_cmd_str
+        return
 
     container_driver = "podman"
     container_command = [
@@ -284,6 +311,12 @@ def _modify_context_impl(
     for env_var_name, env_var_value in os.environ.items():
         if env_var_name.startswith("RAY_"):
             env_vars[env_var_name] = env_var_value
+
+    extra_env_keys = os.getenv("RAY_PODMAN_EXTRA_ENV_KEYS", "")
+    if extra_env_keys:
+        for key in (k.strip() for k in extra_env_keys.split(",")):
+            if key and key in os.environ:
+                env_vars[key] = os.environ[key]
 
     # Support for runtime_env['env_vars']
     env_vars.update(context.env_vars)

--- a/python/ray/tests/runtime_env_container/test_image_uri.py
+++ b/python/ray/tests/runtime_env_container/test_image_uri.py
@@ -1,0 +1,16 @@
+import asyncio
+import logging
+from ray._private.runtime_env.image_uri import _apply_output_filter
+
+
+def test_apply_output_filter_with_grep_v_head():    
+    logger = logging.getLogger(__name__)
+    worker_path = """time=1234567890
+                    /path/to/worker.py
+                    time=1234567891
+                    /other/path/file.py
+                    time=1234567892
+                    /final/path/worker.py"""
+    
+    result = asyncio.run(_apply_output_filter(logger, worker_path, "grep -v '^time=' | head -1")) 
+    assert result.strip() == "/path/to/worker.py"


### PR DESCRIPTION
<!-- Thank you for your contribution! Please review https://github.com/ray-project/ray/blob/master/CONTRIBUTING.rst before opening a pull request. -->

<!-- Please add a reviewer to the assignee section when you create a PR. If you don't have the access to it, we will shortly find a reviewer and assign them to your PR. -->

## Why are these changes needed?
The community has asked whether AntRay provides a prebuilt Docker image. Currently, there is no official prebuilt image published. This PR addresses the request by providing a ready-to-use docker image for AntRay development, following the `build-docker-ant.sh`, and is available from the Alibaba Docker Registry.
<!-- Please give a short summary of the change and the problem this solves. -->

## Related issue number
https://github.com/antgroup/ant-ray/issues/603
<!-- For example: "Closes #1234" -->

## Checks

- [x] I've signed off every commit(by using the -s flag, i.e., `git commit -s`) in this PR.
- [x] I've run `scripts/format.sh` to lint the changes in this PR.
- [x] I've included any doc changes needed for https://docs.ray.io/en/master/.
    - [x] I've added any new APIs to the API Reference. For example, if I added a
           method in Tune, I've added it in `doc/source/tune/api/` under the
           corresponding `.rst` file.
- [x] I've made sure the tests are passing. Note that there might be a few flaky tests, see the recent failures at https://flakey-tests.ray.io/
- Testing Strategy
   - [ ] Unit tests
   - [x] Release tests
   - [ ] This PR is not tested :(

## Summary by Sourcery

Documentation:
- Add a reference in the Docker build script comments to a pre-built AntRay image hosted on Alibaba Cloud Container Registry.