### PR TITLE
[Core] Refactor NodeHead module by optimizing flow insight dependency imports to load only when enabled

### DIFF
--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -590,7 +590,11 @@ class NodeHead(SubprocessModule):
         lm_summary_dict = status_dict.get("load_metrics_report")
         lm_summary = LoadMetricsSummary(**lm_summary_dict) if lm_summary_dict else None
 
-        node_logical_resources = get_per_node_breakdown_as_dict(lm_summary)
+        node_logical_resources = (
+            get_per_node_breakdown_as_dict(lm_summary)
+            if lm_summary and lm_summary.usage_by_node
+            else {}
+        )
         return node_logical_resources if error is None else {}
 
     @routes.get("/nodes")

--- a/python/ray/dashboard/modules/node/node_head.py
+++ b/python/ray/dashboard/modules/node/node_head.py
@@ -27,11 +27,6 @@ from ray._private.ray_constants import (
     DEBUG_AUTOSCALING_STATUS,
     env_integer,
 )
-from ray.autoscaler._private.util import (
-    LoadMetricsSummary,
-    get_per_node_breakdown_as_dict,
-    parse_usage,
-)
 from ray.core.generated import gcs_pb2, node_manager_pb2, node_manager_pb2_grpc
 from ray.dashboard.consts import (
     DASHBOARD_AGENT_ADDR_IP_PREFIX,
@@ -44,28 +39,6 @@ from ray.dashboard.modules.reporter.reporter_models import StatsPayload
 from ray.dashboard.subprocesses.module import SubprocessModule
 from ray.dashboard.subprocesses.routes import SubprocessRouteTable as routes
 from ray.dashboard.utils import async_loop_forever
-
-from ray.util.insight import (
-    create_http_insight_client,
-)
-from ray._private.test_utils import get_resource_usage
-from ray.dashboard.modules.insight.insight_prompt import PROMPT_TEMPLATE
-from flow_insight import (
-    BatchNodePhysicalStatsEvent,
-    BatchNodePhysicalStats,
-    NodePhysicalStats,
-    NodeResourceUsage,
-    DeviceInfo,
-    BatchServicePhysicalStatsEvent,
-    ServicePhysicalStats,
-    ServiceState,
-    MemoryInfo,
-    DeviceType,
-    Service,
-    ServicePhysicalStatsRecord,
-    NodeMemoryInfo,
-    MetaInfoRegisterEvent,
-)
 
 logger = logging.getLogger(__name__)
 
@@ -210,20 +183,6 @@ class NodeHead(SubprocessModule):
             "module_lifetime_s": time.time() - self._module_start_time,
         }
 
-    def _to_service_state(self, state: str) -> ServiceState:
-        if state == "ALIVE":
-            return ServiceState.RUNNING
-        elif (
-            state == "DEPENDENCIES_UNREADY"
-            or state == "PENDING_CREATION"
-            or state == "RESTARTING"
-        ):
-            return ServiceState.WAITING
-        elif state == "DEAD":
-            return ServiceState.TERMINATED
-        else:
-            return ServiceState.UNKNOWN
-
     @async_loop_forever(10)
     async def _emit_node_physical_stats(self):
         insight_server_address = await self.gcs_client.async_internal_kv_get(
@@ -233,6 +192,46 @@ class NodeHead(SubprocessModule):
         )
         if insight_server_address is None:
             return
+
+        # flow/insight is optional; only import heavy deps if actually enabled.
+        from ray.util.insight import create_http_insight_client, is_flow_insight_enabled
+
+        if not is_flow_insight_enabled():
+            return
+
+        from ray._private.test_utils import get_resource_usage
+        from ray.dashboard.modules.insight.insight_prompt import PROMPT_TEMPLATE
+
+        from flow_insight import (
+            BatchNodePhysicalStats,
+            BatchNodePhysicalStatsEvent,
+            BatchServicePhysicalStatsEvent,
+            DeviceInfo,
+            DeviceType,
+            MemoryInfo,
+            MetaInfoRegisterEvent,
+            NodeMemoryInfo,
+            NodePhysicalStats,
+            NodeResourceUsage,
+            Service,
+            ServicePhysicalStats,
+            ServicePhysicalStatsRecord,
+            ServiceState,
+        )
+
+        def to_service_state(state: str):
+            if state == "ALIVE":
+                return ServiceState.RUNNING
+            elif (
+                state == "DEPENDENCIES_UNREADY"
+                or state == "PENDING_CREATION"
+                or state == "RESTARTING"
+            ):
+                return ServiceState.WAITING
+            elif state == "DEAD":
+                return ServiceState.TERMINATED
+            else:
+                return ServiceState.UNKNOWN
         self._insight_server_address = insight_server_address.decode()
 
         if self._insight_client is None:
@@ -308,7 +307,7 @@ class NodeHead(SubprocessModule):
                 service_stats = ServicePhysicalStats(
                     node_id=node_id,
                     pid=actor_pid,
-                    state=self._to_service_state(actor_info.get("state", "UNKNOWN")),
+                    state=to_service_state(actor_info.get("state", "UNKNOWN")),
                     required_resources=actor_info.get("requiredResources", {}),
                     placement_id=actor_info.get("placementGroupId", None),
                     cpu_percent=0,
@@ -532,6 +531,7 @@ class NodeHead(SubprocessModule):
         if is_autoscaler_v2():
             from ray.autoscaler.v2.schema import Stats
             from ray.autoscaler.v2.sdk import ClusterStatusParser
+            from ray.autoscaler._private.util import parse_usage
 
             try:
                 # here we have a sync request
@@ -580,9 +580,15 @@ class NodeHead(SubprocessModule):
             return {}
         status_dict = json.loads(status_string)
 
+        # Legacy autoscaler load metrics parsing is relatively heavy; import only
+        # when needed (this code path is hit only for the legacy autoscaler).
+        from ray.autoscaler._private.util import (
+            LoadMetricsSummary,
+            get_per_node_breakdown_as_dict,
+        )
+
         lm_summary_dict = status_dict.get("load_metrics_report")
-        if lm_summary_dict:
-            lm_summary = LoadMetricsSummary(**lm_summary_dict)
+        lm_summary = LoadMetricsSummary(**lm_summary_dict) if lm_summary_dict else None
 
         node_logical_resources = get_per_node_breakdown_as_dict(lm_summary)
         return node_logical_resources if error is None else {}


### PR DESCRIPTION
## Motivation

NodeHead, as one of the dashboard subprocesses, currently loads a batch of dependencies at process startup that are only needed in specific feature scenarios (especially flow/insight and some autoscaler helper logic). Changing to lazy loading can reduce the base memory footprint of each NodeHead subprocess and shorten import time during startup; in clusters, these savings are amplified by the number of subprocesses.

## Changes

- Move flow/insight related heavy dependencies (ray.util.insight / flow_insight / get_resource_usage / PROMPT_TEMPLATE, etc.) from the module top level to inside `_emit_node_physical_stats()`, importing them only when `insight_monitor_address` is detected and the feature is enabled.
- Move autoscaler related utility functions (parse_usage, LoadMetricsSummary, get_per_node_breakdown_as_dict) to their actual usage code paths (autoscaler v2 / legacy branches), reducing unnecessary startup-time imports.
- Refactor `_to_service_state` to a local function `to_service_state` inside `_emit_node_physical_stats()`, avoiding top-level symbol coupling for optional dependencies.

## Unit Tests

- test_node_head_get_nodes_logical_resources_autoscaler_v2_smoke
  - Force the autoscaler v2 branch (mock `is_autoscaler_v2=True`)
  - Mock `ClusterStatusParser.from_get_cluster_status_reply` and `parse_usage`
  - Verify the return value matches expectations, ensuring no regression of undefined `parse_usage`

## Impact
<img width="646" height="36" alt="image" src="https://github.com/user-attachments/assets/22f1457a-02b7-470e-aae0-4e8871c32f96" />
<img width="623" height="34" alt="image" src="https://github.com/user-attachments/assets/1a1f283c-5d43-499c-9517-40733398330e" />

NodeHead RSS reduced by approximately 10MB

## Statistics Script

```bash
ps -aux | grep -E 'ray-dashboard' | grep -v grep | awk '{
    rss_mb = $6 / 1024;
    total += rss_mb;
    printf "PID: %-6s RSS: %-8.2f MB CMD: %s\n", $2, rss_mb, $11
} END {
    printf "=====================================\n"
    printf "Total RSS Memory: %-8.2f MB\n", total
}'
```


