### PR TITLE
[Data] Add schema inference capabilities to logical operators

### DIFF
--- a/python/ray/data/BUILD.bazel
+++ b/python/ray/data/BUILD.bazel
@@ -2000,3 +2000,17 @@ py_test(
         "//:ray_lib",
     ],
 )
+
+py_test(
+    name = "test_infer_schema",
+    size = "small",
+    srcs = ["tests/test_infer_schema.py"],
+    tags = [
+        "exclusive",
+        "team:data",
+    ],
+    deps = [
+        ":conftest",
+        "//:ray_lib",
+    ],
+)

--- a/python/ray/data/_internal/logical/operators/count_operator.py
+++ b/python/ray/data/_internal/logical/operators/count_operator.py
@@ -1,4 +1,7 @@
+from typing import Optional
+
 from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data.block import Schema
 
 
 class Count(LogicalOperator):
@@ -16,3 +19,8 @@ class Count(LogicalOperator):
         input_op: LogicalOperator,
     ):
         super().__init__("Count", [input_op])
+
+    def infer_schema(self) -> Optional["Schema"]:
+        import pyarrow as pa
+
+        return pa.schema([pa.field(self.COLUMN_NAME, pa.int64())])

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -22,6 +22,7 @@ from ray.data.expressions import (
     StarExpr,
     UDFExpr,
     UnaryExpr,
+    Operation,
 )
 from ray.data.preprocessor import Preprocessor
 
@@ -462,24 +463,30 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
             if left_type is None or right_type is None:
                 return None
 
-            op = expr.op.value
-            if op == "div":
+            op = expr.op
+            if op == Operation.DIV:
                 return pa.float64()
-            if op in ["add", "sub", "mul", "floordiv", "mod"]:
+            if op in [
+                Operation.ADD,
+                Operation.SUB,
+                Operation.MUL,
+                Operation.FLOORDIV,
+                Operation.MOD,
+            ]:
                 if pa.types.is_integer(left_type) and pa.types.is_integer(right_type):
                     return pa.int64()
                 return pa.float64()
             elif op in [
-                "eq",
-                "ne",
-                "lt",
-                "le",
-                "gt",
-                "ge",
-                "and",
-                "or",
-                "in",
-                "not_in",
+                Operation.EQ,
+                Operation.NE,
+                Operation.LT,
+                Operation.LE,
+                Operation.GT,
+                Operation.GE,
+                Operation.AND,
+                Operation.OR,
+                Operation.IN,
+                Operation.NOT_IN,
             ]:
                 return pa.bool_()
 

--- a/python/ray/data/_internal/logical/operators/map_operator.py
+++ b/python/ray/data/_internal/logical/operators/map_operator.py
@@ -10,8 +10,19 @@ from ray.data._internal.logical.interfaces import (
     PredicatePassThroughBehavior,
 )
 from ray.data._internal.logical.operators.one_to_one_operator import AbstractOneToOne
-from ray.data.block import UserDefinedFunction
-from ray.data.expressions import Expr, StarExpr
+from ray.data.block import Schema, UserDefinedFunction
+from ray.data.datatype import DataType
+from ray.data.expressions import (
+    AliasExpr,
+    BinaryExpr,
+    ColumnExpr,
+    DownloadExpr,
+    Expr,
+    LiteralExpr,
+    StarExpr,
+    UDFExpr,
+    UnaryExpr,
+)
 from ray.data.preprocessor import Preprocessor
 
 logger = logging.getLogger(__name__)
@@ -293,6 +304,11 @@ class Filter(AbstractUDFMap):
             return f"{op_name}({expr_str})"
         return super()._get_operator_name(op_name, fn)
 
+    def infer_schema(self) -> Optional["Schema"]:
+        if not self._input_dependencies:
+            return None
+        return self._input_dependencies[0].infer_schema()
+
 
 class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
     """Logical operator for all Projection Operations."""
@@ -384,6 +400,104 @@ class Project(AbstractMap, LogicalOperatorSupportsPredicatePassThrough):
         rename_map = _extract_input_columns_renaming_mapping(self._exprs)
         return rename_map if rename_map else None
 
+    def infer_schema(self) -> Optional["Schema"]:
+        input_schema = self._input_dependencies[0].infer_schema()
+        if input_schema is None:
+            return None
+
+        return self._compute_projection_schema(input_schema)
+
+    def _compute_projection_schema(self, input_schema: "Schema") -> Optional["Schema"]:
+        import pyarrow as pa
+
+        fields = []
+        for expr in self._exprs:
+            field_name = expr.name
+            if isinstance(expr, StarExpr):
+                renamed_cols = [
+                    expr.expr.name
+                    for expr in self._exprs
+                    if isinstance(expr, AliasExpr) and expr._is_rename
+                ]
+
+                for f in input_schema:
+                    # filter out renamed columns
+                    if f.name not in renamed_cols:
+                        fields.append(f)
+            else:
+                field_type = self._infer_expr_type(expr, input_schema)
+                if field_type is None:
+                    # if the type cannot be inferred, we fall back to string
+                    field_type = pa.string()
+                fields.append(pa.field(field_name, field_type))
+        return pa.schema(fields)
+
+    def _infer_expr_type(self, expr: "Expr", input_schema: "Schema") -> "Schema":
+        """Infer the data type of expressions.
+
+        Args:
+            expr: Expression object.
+            input_schema: Input schema.
+
+        Returns:
+            Inferred PyArrow data type.
+        """
+        import pyarrow as pa
+
+        if isinstance(expr, AliasExpr):
+            return self._infer_expr_type(expr.expr, input_schema)
+        elif isinstance(expr, ColumnExpr):
+            try:
+                return input_schema.field(expr.name).type
+            except KeyError:
+                return None
+        elif isinstance(expr, UDFExpr):
+            return expr.data_type.to_arrow_dtype()
+        elif isinstance(expr, BinaryExpr):
+            # Binary expression, infer type based on operator
+            left_type = self._infer_expr_type(expr.left, input_schema)
+            right_type = self._infer_expr_type(expr.right, input_schema)
+
+            # If either operand type cannot be inferred return None
+            if left_type is None or right_type is None:
+                return None
+
+            op = expr.op.value
+            if op == "div":
+                return pa.float64()
+            if op in ["add", "sub", "mul", "floordiv", "mod"]:
+                if pa.types.is_integer(left_type) and pa.types.is_integer(right_type):
+                    return pa.int64()
+                return pa.float64()
+            elif op in [
+                "eq",
+                "ne",
+                "lt",
+                "le",
+                "gt",
+                "ge",
+                "and",
+                "or",
+                "in",
+                "not_in",
+            ]:
+                return pa.bool_()
+
+            return pa.string()
+        elif isinstance(expr, UnaryExpr):
+            return pa.bool_()
+        elif isinstance(expr, LiteralExpr):
+            # literal expression, infer type from value
+            value = expr.value
+            if value is None:
+                return pa.string()
+
+            return DataType.infer_dtype(value).to_arrow_dtype()
+        elif isinstance(expr, DownloadExpr):
+            # download expression, return binary data
+            return pa.binary()
+        return pa.string()
+
 
 class FlatMap(AbstractUDFMap):
     """Logical operator for flat_map."""
@@ -437,3 +551,9 @@ class StreamingRepartition(AbstractMap):
     @property
     def target_num_rows_per_block(self) -> int:
         return self._target_num_rows_per_block
+
+    def infer_schema(self) -> Optional["Schema"]:
+        if not self._input_dependencies:
+            return None
+
+        return self._input_dependencies[0].infer_schema()

--- a/python/ray/data/tests/test_filter.py
+++ b/python/ray/data/tests/test_filter.py
@@ -444,7 +444,8 @@ def test_filter_expression_display_names(ray_start_regular_shared):
     def _str_len(array):
         return pc.greater(pc.binary_length(array), 0)
 
-    plan_str = str(ray.data.from_items(["a", ""]).filter(expr=_str_len(col("item"))))
+    ds = ray.data.from_items(["a", ""]).filter(expr=_str_len(col("item")))
+    plan_str = ds._plan.get_plan_as_string(ds.__class__)
     assert plan_str == (
         "Filter(_str_len(col('item')))\n"
         "+- Dataset(num_rows=2, schema={item: string})"

--- a/python/ray/data/tests/test_groupby_e2e.py
+++ b/python/ray/data/tests/test_groupby_e2e.py
@@ -66,7 +66,7 @@ def test_groupby_arrow(
     target_max_block_size_infinite_or_default,
 ):
     # Test empty dataset.
-    agg_ds = ray.data.range(10).filter(lambda r: r["id"] > 10).groupby("value").count()
+    agg_ds = ray.data.range(10).filter(lambda r: r["id"] > 10).groupby("id").count()
     assert agg_ds.count() == 0
 
 

--- a/python/ray/data/tests/test_infer_schema.py
+++ b/python/ray/data/tests/test_infer_schema.py
@@ -1,0 +1,270 @@
+import sys
+from typing import Optional
+
+import pyarrow as pa
+import pytest
+
+from ray.data._internal.logical.interfaces import LogicalOperator
+from ray.data._internal.logical.operators.all_to_all_operator import Repartition
+from ray.data._internal.logical.operators.count_operator import Count
+from ray.data._internal.logical.operators.map_operator import Filter, Project
+from ray.data.expressions import (
+    BinaryExpr,
+    ColumnExpr,
+    LiteralExpr,
+    Operation,
+    StarExpr,
+    UnaryExpr,
+    col,
+    download,
+)
+
+
+class MockLogicalOperator(LogicalOperator):
+    """Mock logical operator for testing."""
+
+    def __init__(self, schema: Optional[pa.Schema] = None):
+        super().__init__("MockOperator", [])
+        self._schema = schema
+
+    def infer_schema(self) -> Optional[pa.Schema]:
+        return self._schema
+
+
+class TestSchemaInference:
+    def test_filter_schema_inference(self):
+        """Test Filter operator schema inference."""
+        input_schema = pa.schema(
+            [("id", pa.int64()), ("name", pa.string()), ("value", pa.float64())]
+        )
+
+        input_op = MockLogicalOperator(input_schema)
+
+        def filter_fn(x):
+            return x["value"] > 0
+
+        filter_op = Filter(input_op, fn=filter_fn)
+        result_schema = filter_op.infer_schema()
+
+        assert result_schema == input_schema
+
+    def test_count_schema_inference(self):
+        """Test Count operator schema inference."""
+        input_op = MockLogicalOperator(pa.schema([("id", pa.int64())]))
+        count_op = Count(input_op)
+        result_schema = count_op.infer_schema()
+
+        expected_schema = pa.schema([(Count.COLUMN_NAME, pa.int64())])
+        assert result_schema == expected_schema
+
+    def test_project_simple_fields(self):
+        """Test projecting simple fields."""
+        input_schema = pa.schema(
+            [("id", pa.int64()), ("name", pa.string()), ("age", pa.int32())]
+        )
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [ColumnExpr("id"), ColumnExpr("name")]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 2
+        assert result_schema.field("id").type == pa.int64()
+        assert result_schema.field("name").type == pa.string()
+
+    def test_project_with_alias(self):
+        """Test projecting with aliases."""
+        input_schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [
+            ColumnExpr("id").alias("user_id"),
+            ColumnExpr("name").alias("user_name"),
+        ]
+
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 2
+        assert result_schema.field("user_id").type == pa.int64()
+        assert result_schema.field("user_name").type == pa.string()
+
+    def test_project_with_star(self):
+        """Test projecting with star expression."""
+        input_schema = pa.schema(
+            [("id", pa.int64()), ("name", pa.string()), ("age", pa.int32())]
+        )
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [StarExpr(), ColumnExpr("age").alias("user_age")]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 4
+        assert result_schema.field("id").type == pa.int64()
+        assert result_schema.field("name").type == pa.string()
+        assert result_schema.field("age").type == pa.int32()
+        assert result_schema.field("user_age").type == pa.int32()
+
+    def test_project_mixed_expressions(self):
+        """Test projecting with mixed expressions."""
+        input_schema = pa.schema(
+            [("id", pa.int64()), ("price", pa.float64()), ("quantity", pa.int32())]
+        )
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [
+            ColumnExpr("id"),
+            BinaryExpr(Operation.MUL, col("price"), col("quantity")).alias("total"),
+        ]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 2
+        assert result_schema.field("id").type == pa.int64()
+        assert result_schema.field("total").type == pa.float64()
+
+    def test_project_with_literal(self):
+        """Test projecting with literal values."""
+        input_schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [
+            LiteralExpr(42).alias("constant_int"),
+            LiteralExpr("hello").alias("constant_str"),
+            LiteralExpr(True).alias("constant_bool"),
+            LiteralExpr(3.14).alias("constant_float"),
+            LiteralExpr([1, 2, 3]).alias("constant_list"),
+        ]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 5
+        assert result_schema.field("constant_int").type == pa.int64()
+        assert result_schema.field("constant_str").type == pa.string()
+        assert result_schema.field("constant_bool").type == pa.bool_()
+        assert result_schema.field("constant_float").type == pa.float64()
+        assert result_schema.field("constant_list").type == pa.list_(pa.int64())
+
+    def test_project_empty_input(self):
+        """Test projecting with empty input schema."""
+        input_schema = pa.schema([])
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [ColumnExpr("nonexistent")]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema.field("nonexistent").type == pa.string()
+
+    def test_project_none_input(self):
+        """Test projecting when input schema is None."""
+        mock_input = MockLogicalOperator(None)
+
+        exprs = [ColumnExpr("test")]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is None
+
+    def test_project_binary_expressions(self):
+        """Test projecting with various binary expressions."""
+        input_schema = pa.schema(
+            [
+                ("a", pa.int64()),
+                ("b", pa.int64()),
+                ("price", pa.float64()),
+                ("name", pa.string()),
+            ]
+        )
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [
+            BinaryExpr(Operation.ADD, col("a"), col("b")).alias("sum_ab"),
+            BinaryExpr(Operation.MUL, col("price"), col("a")).alias("total_price"),
+            BinaryExpr(Operation.EQ, col("a"), col("b")).alias("is_equal"),
+        ]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 3
+        assert result_schema.field("sum_ab").type == pa.int64()
+        assert result_schema.field("total_price").type == pa.float64()
+        assert result_schema.field("is_equal").type == pa.bool_()
+
+    def test_project_unary_expressions(self):
+        """Test projecting with unary expressions."""
+        input_schema = pa.schema([("flag", pa.bool_()), ("value", pa.int64())])
+
+        mock_input = MockLogicalOperator(input_schema)
+        exprs = [
+            UnaryExpr(Operation.NOT, col("flag")).alias("not_flag"),
+            UnaryExpr(Operation.IS_NOT_NULL, col("value")).alias("is_not_null"),
+        ]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 2
+        assert result_schema.field("not_flag").type == pa.bool_()
+        assert result_schema.field("is_not_null").type == pa.bool_()
+
+    def test_project_rename_expressions(self):
+        """Test projecting with rename expressions"""
+        input_schema = pa.schema([("foo", pa.int64()), ("bar", pa.string())])
+
+        mock_input = MockLogicalOperator(input_schema)
+        exprs = [
+            StarExpr(),
+            col("bar")._rename("new_bar"),
+        ]
+        project = Project(mock_input, exprs)
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 2
+        assert result_schema.field("foo").type == pa.int64()
+        assert result_schema.field("new_bar").type == pa.string()
+
+    def test_project_download_expressions(self):
+        """Test projecting with download expressions."""
+        input_schema = pa.schema([("url", pa.string()), ("filename", pa.string())])
+
+        mock_input = MockLogicalOperator(input_schema)
+
+        exprs = [
+            download("url").alias("downloaded_content"),
+            ColumnExpr("filename"),
+        ]
+        project = Project(mock_input, exprs)
+
+        result_schema = project.infer_schema()
+        assert result_schema is not None
+        assert len(result_schema) == 2
+        assert result_schema.field("downloaded_content").type == pa.binary()
+        assert result_schema.field("filename").type == pa.string()
+
+    def test_repartition_schema_inference(self):
+        """Test Repartition operator schema inference."""
+        input_schema = pa.schema([("id", pa.int64()), ("name", pa.string())])
+
+        input_op = MockLogicalOperator(input_schema)
+        repartition = Repartition(input_op, 4, shuffle=False)
+        result_schema = repartition.infer_schema()
+
+        assert result_schema == input_schema
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main(["-v", __file__]))


### PR DESCRIPTION
## Description

- Add infer_schema method to Count, Map, Filter, Project, and Repartition operators

- Implement expression type inference for various expression types including BinaryExpr, UnaryExpr, LiteralExpr

- Add projection schema computation logic with proper field type derivation

## Related issues

No

